### PR TITLE
Use entrypoint link titles, if available.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import Link from './link';
 import Resource from './resource';
 import { request } from './lib/request';
+import { extract } from './utils';
 
 const url = process.env.TOP_LEVEL;
 
@@ -52,9 +53,13 @@ const App = () => {
         <h2>Resources</h2>
         <ul className="scrollable scrollable_y">
           {Object.keys(resourceLinks).map((type, index) => (
-            <li key={`resource-link-${index}`}>
-              <Link title={type} url={resourceLinks[type].href} handleClick={updateDocument} />
-            </li>
+              <li key={`resource-link-${index}`}>
+                <Link
+                    title={extract(resourceLinks[type], 'meta.linkParams.title', type)}
+                    url={resourceLinks[type].href}
+                    handleClick={updateDocument}
+                />
+              </li>
           ))}
         </ul>
       </nav>

--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from 'react';
 
-import Link from './link';
+import { Link, LinkElement } from './link';
 import Resource from './resource';
 import { request } from './lib/request';
-import { extract } from './utils';
 
 const url = process.env.TOP_LEVEL;
 
@@ -18,7 +17,7 @@ const App = () => {
       const response = await request(url);
 
       setQuery(url);
-      setResourceLinks(response.links);
+      setResourceLinks(Link.parseLinks(response.links));
     };
 
     fetchDocument(url);
@@ -30,7 +29,7 @@ const App = () => {
       const response = await request(url);
 
       setQuery(url);
-      setLinks(response.links);
+      setLinks(Link.parseLinks(response.links));
       setResult(response);
     };
 
@@ -52,13 +51,9 @@ const App = () => {
       <nav className="pane resourceLinks">
         <h2>Resources</h2>
         <ul className="scrollable scrollable_y">
-          {Object.keys(resourceLinks).map((type, index) => (
+          {Object.keys(resourceLinks).map((key, index) => (
               <li key={`resource-link-${index}`}>
-                <Link
-                    title={extract(resourceLinks[type], 'meta.linkParams.title', type)}
-                    url={resourceLinks[type].href}
-                    handleClick={updateDocument}
-                />
+                <LinkElement link={resourceLinks[key]} handleClick={updateDocument} />
               </li>
           ))}
         </ul>

--- a/src/link.js
+++ b/src/link.js
@@ -1,9 +1,26 @@
 import React from 'react';
 
-const Link = ({title, url, handleClick}) => (
+import { extract } from "./utils";
 
-  <button onClick={() => handleClick(url)}>{title}</button>
+
+class Link {
+
+    constructor({href, meta}, text = '') {
+        this.href = href;
+        this.text = extract(meta, 'linkParams.title', text);
+    }
+
+    static parseLinks(links) {
+        return Object.keys(links).reduce((parsed, key) => Object.assign(parsed, {
+            [key]: new Link(links[key], key),
+        }), {});
+    }
+
+}
+
+const LinkElement = ({link, handleClick}) => (
+  <button onClick={() => handleClick(link.href)}>{link.text}</button>
 );
 
 
-export default Link;
+export { Link, LinkElement };

--- a/src/resource.js
+++ b/src/resource.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
-import Link from './link';
+import { LinkElement } from './link';
 import DisplayRaw from './displayRaw';
 import Schema from './schema';
 
@@ -64,9 +64,9 @@ const Resource = ({ result, links, updateDocument }) => {
       <div className="results-container">
         <div className="pane links">
           <ul>
-            {Object.keys(resourceLinks).map((type, index) => (
+            {Object.keys(resourceLinks).map((key, index) => (
               <li key={`link-${index}`}>
-                <Link title={type} url={resourceLinks[type].href} handleClick={updateDocument} />
+                <LinkElement link={resourceLinks[key]} handleClick={updateDocument} />
               </li>
             ))}
           </ul>

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,4 @@
+export function extract(obj, path, dflt) {
+    const $n = {};
+    return path.split('.').reduce((obj, key) => (obj||$n)[key], obj) || dflt;
+}


### PR DESCRIPTION
If you pull the latest for `jsonapi_schema`, I added link titles to the links on the entrypoint (`/jsonapi`).

It's a minor thing but I think it'll encourage good practices w/ JSON:API Hypermedia if we surface these link titles wherever we make a link into a button.