### PR TITLE
Add and use a `document` property to the `LocationContext`

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,7 +8,7 @@ const homeUrl = process.env.TOP_LEVEL;
 const App = () => {
   return (
       <Location homeUrl={homeUrl}>
-        <ExplorerUI homeUrl={homeUrl}/>
+        <ExplorerUI />
       </Location>
   );
 };

--- a/src/explorer-ui.js
+++ b/src/explorer-ui.js
@@ -2,63 +2,36 @@ import React, { useState, useEffect, useContext } from 'react';
 
 import { Link, LinkElement } from './link';
 import Resource from './resource';
-import { request } from './lib/request';
 import { LocationContext } from './location';
 
-const ExplorerUI = ({ homeUrl }) => {
-    const location = useContext(LocationContext);
-    const [result, setResult] = useState([]);
-    const [links, setLinks] = useState([]);
-    const [resourceLinks, setResourceLinks] = useState([]);
-
-    const loadTopLevel = () => {
-        const fetchDocument = async (url) => {
-            const response = await request(url);
-            setResourceLinks(Link.parseLinks(response.links));
-        };
-
-        fetchDocument(homeUrl);
-    };
-
-    const updateDocument = () => {
-        const fetchDocument = async (url) => {
-            const response = await request(url);
-            setLinks(Link.parseLinks(response.links));
-            setResult(response);
-        };
-
-        fetchDocument(location.locationUrl);
-    };
-
+const ExplorerUI = () => {
+    const { locationUrl, document, onEntryPoint } = useContext(LocationContext);
+    const [ entryPointLinks, setEntryPointLinks ] = useState({});
+    const parsedLinks = document.links ? Link.parseLinks(document.links) : {};
 
     useEffect(() => {
-        if (location.locationUrl === homeUrl) {
-            loadTopLevel();
-        }
-        else {
-            updateDocument();
-        }
-    }, [location.locationUrl]);
+      if (onEntryPoint) setEntryPointLinks(parsedLinks);
+    }, [onEntryPoint]);
 
     return (
         <div className="container">
             <header className="location">
                 <div className="pane query">
                     <h2>Query</h2>
-                    <div className="scrollable scrollable_x query-url">{location.locationUrl}</div>
+                    <div className="scrollable scrollable_x query-url">{locationUrl}</div>
                 </div>
             </header>
             <nav className="pane resourceLinks">
                 <h2>Resources</h2>
                 <ul className="scrollable scrollable_y">
-                    {Object.keys(resourceLinks).map((key, index) => (
+                    {Object.keys(entryPointLinks).map((key, index) => (
                         <li key={`resource-link-${index}`}>
-                            <LinkElement link={resourceLinks[key]} />
+                            <LinkElement link={entryPointLinks[key]} />
                         </li>
                     ))}
                 </ul>
             </nav>
-            <Resource result={result} links={links} />
+            <Resource links={!onEntryPoint ? parsedLinks : {}} />
         </div>
     );
 };

--- a/src/resource.js
+++ b/src/resource.js
@@ -9,7 +9,7 @@ const Resource = ({ links }) => {
   const { document, setInclude, toggleField, clearFieldSet, setSort } = useContext(LocationContext);
   const { describedBy = null, ...resourceLinks } = links;
   const schemaUrl = describedBy ? describedBy.href : '';
-  const {data = [], included = [] } = document;;
+  const {data = [], included = [] } = document;
 
   return (
     <main>

--- a/src/resource.js
+++ b/src/resource.js
@@ -5,26 +5,11 @@ import DisplayRaw from './displayRaw';
 import Schema from './schema';
 import { LocationContext } from "./location";
 
-const Resource = ({ result, links }) => {
-  const { setInclude, toggleField, clearFieldSet, setSort } = useContext(LocationContext);
-  const [schemaUrl, setSchemaUrl] = useState('');
-  const [resourceLinks, setResourceLinks] = useState([]);
-
-  const {data = [], included = [] } = result;
-
-  const loadMeta = () => {
-
-    if (links.hasOwnProperty('describedBy')) {
-      const { describedBy, ...additionalLinks } = links;
-
-      setSchemaUrl(describedBy.href);
-      setResourceLinks(additionalLinks);
-    }
-  };
-
-  useEffect(() => {
-    loadMeta();
-  }, [links]);
+const Resource = ({ links }) => {
+  const { document, setInclude, toggleField, clearFieldSet, setSort } = useContext(LocationContext);
+  const { describedBy = null, ...resourceLinks } = links;
+  const schemaUrl = describedBy ? describedBy.href : '';
+  const {data = [], included = [] } = document;;
 
   return (
     <main>
@@ -63,7 +48,7 @@ const Resource = ({ result, links }) => {
         <div className="pane schema">
           <Schema url={schemaUrl} />
         </div>
-        <DisplayRaw title="Results" name="results" data={result}>
+        <DisplayRaw title="Results" name="results" data={document}>
           <div>
             <h3>Data</h3>
             <ul>


### PR DESCRIPTION
This fetches and places the response document into the location context.

Also, it adds a `onEntryPoint` boolean property to the context so that components can tell if the current view is of the home URL (`/jsonapi`). Aside: While I think this cleans things up a bit, I'm still not sure I like the idea of resource links being persistent. It makes me nervous because we're hardcoding a Drupal-ism (the existence of `/jsonapi` is not part of the spec or its recommendations) into the explorer.
