### PR TITLE
Require prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-loader": "^8.0.6",
     "jest": "^24.8.0",
     "path": "^0.12.7",
+    "prettier": "1.17.1",
     "react-hot-loader": "^4.8.7",
     "webpack": "^4.32.0",
     "webpack-cli": "^3.3.2",


### PR DESCRIPTION
This adds prettier to the package.json, and a basic config file.
Keeping most of the defaults.

https://prettier.io/docs/en/options.html