### PR TITLE
Enable includes

### DIFF
--- a/src/location.js
+++ b/src/location.js
@@ -98,7 +98,7 @@ const Location = ({ homeUrl, children }) => {
           delete newFieldsParam[type];
           updateQuery({ fields: newFieldsParam });
         },
-        setInclude: newParam => updateQuery({ include: newParam }),
+        setInclude: newParam => updateQuery({ include: [newParam] }),
         setSort: newParam => updateQuery({ sort: newParam }),
         setFragment: fragment =>
           setParsedUrl(Object.assign({}, parsedUrl, { fragment })),

--- a/src/location.js
+++ b/src/location.js
@@ -29,9 +29,9 @@ const compileJsonApiUrl = ({ protocol, host, port, path, query, fragment }) => {
     )
     .map(name => {
       return name === 'fields'
-        ? Object.keys(query[name]).map(
-            type => `fields[${type}]=${[...query.fields[type]].join(',')}`,
-          ).join('&')
+        ? Object.keys(query[name])
+            .map(type => `fields[${type}]=${[...query.fields[type]].join(',')}`)
+            .join('&')
         : `${name}=${query[name].join(',')}`;
     })
     .join('&');
@@ -88,7 +88,7 @@ const Location = ({ homeUrl, children }) => {
             : new Set();
 
           const newParam = Object.assign({}, queryFields, {
-            [type]: toggleSetEntry(fieldSet, field)
+            [type]: toggleSetEntry(fieldSet, field),
           });
           updateQuery({ fields: newParam });
         },
@@ -100,7 +100,7 @@ const Location = ({ homeUrl, children }) => {
         toggleInclude: path => {
           const includeList = extract(parsedUrl, `query.include`);
           updateQuery({
-            include: Array.from(toggleSetEntry(new Set(includeList), path))
+            include: Array.from(toggleSetEntry(new Set(includeList), path)),
           });
         },
         setSort: newParam => updateQuery({ sort: newParam }),

--- a/src/location.js
+++ b/src/location.js
@@ -31,7 +31,7 @@ const compileJsonApiUrl = ({ protocol, host, port, path, query, fragment }) => {
       return name === 'fields'
         ? Object.keys(query[name]).map(
             type => `fields[${type}]=${[...query.fields[type]].join(',')}`,
-          )
+          ).join('&')
         : `${name}=${query[name].join(',')}`;
     })
     .join('&');
@@ -82,14 +82,13 @@ const Location = ({ homeUrl, children }) => {
         setUrl: newLocationUrl => setParsedUrl(parseJsonApiUrl(newLocationUrl)),
         setFilter: newParam => updateQuery({ filter: newParam }),
         toggleField: (type, field) => {
-          const fieldSet = extract(
-            parsedUrl,
-            `query.fields.${type}`,
-            new Set(),
-          );
-          toggleSetEntry(fieldSet, field);
-          const newParam = Object.assign({}, parsedUrl.fields || {}, {
-            [type]: fieldSet,
+          const queryFields = extract(parsedUrl, 'query.fields');
+          const fieldSet = queryFields.hasOwnProperty(type)
+            ? queryFields[type]
+            : new Set();
+
+          const newParam = Object.assign({}, queryFields, {
+            [type]: toggleSetEntry(fieldSet, field)
           });
           updateQuery({ fields: newParam });
         },
@@ -98,7 +97,12 @@ const Location = ({ homeUrl, children }) => {
           delete newFieldsParam[type];
           updateQuery({ fields: newFieldsParam });
         },
-        setInclude: newParam => updateQuery({ include: [newParam] }),
+        toggleInclude: path => {
+          const includeList = extract(parsedUrl, `query.include`);
+          updateQuery({
+            include: Array.from(toggleSetEntry(new Set(includeList), path))
+          });
+        },
         setSort: newParam => updateQuery({ sort: newParam }),
         setFragment: fragment =>
           setParsedUrl(Object.assign({}, parsedUrl, { fragment })),

--- a/src/schema.js
+++ b/src/schema.js
@@ -9,14 +9,16 @@ import {
   getResourceRef,
 } from './lib/normalize';
 import { request } from './lib/request';
-import { extract } from './utils';
+import { extract, checkIncludesPath } from './utils';
 import { LocationContext } from './location';
 
 const Schema = ({ url, includePath = [] }) => {
   const [type, setType] = useState('');
   const [attributes, setAttributes] = useState([]);
   const [relationships, setRelationships] = useState([]);
-  const { include } = useContext(LocationContext);
+  const { include, setInclude } = useContext(LocationContext);
+
+  const includesEnabled = checkIncludesPath(include, includePath);
 
   useEffect(() => {
     const fetchDocument = async url => {
@@ -45,7 +47,7 @@ const Schema = ({ url, includePath = [] }) => {
       <SchemaAttributes
         attributes={attributes}
         type={type}
-        includesEnabled={new Set(include).has(includePath.join('.'))}
+        includesEnabled={includesEnabled}
       />
       <SchemaRelationships
         relationships={relationships}

--- a/src/schema.js
+++ b/src/schema.js
@@ -16,7 +16,7 @@ const Schema = ({ url, includePath = [] }) => {
   const [type, setType] = useState('');
   const [attributes, setAttributes] = useState([]);
   const [relationships, setRelationships] = useState([]);
-  const { include, setInclude } = useContext(LocationContext);
+  const { include, toggleInclude } = useContext(LocationContext);
 
   const includesEnabled = checkIncludesPath(include, includePath);
   const includePathDisplay = includePath.join('.');
@@ -50,7 +50,7 @@ const Schema = ({ url, includePath = [] }) => {
           <input
             type="checkbox"
             checked={includesEnabled}
-            onChange={() => setInclude(includePathDisplay)}
+            onChange={() => toggleInclude(includePathDisplay)}
           />
           {includePathDisplay}
         </div>

--- a/src/schema.js
+++ b/src/schema.js
@@ -19,6 +19,7 @@ const Schema = ({ url, includePath = [] }) => {
   const { include, setInclude } = useContext(LocationContext);
 
   const includesEnabled = checkIncludesPath(include, includePath);
+  const includePathDisplay = includePath.join('.');
 
   useEffect(() => {
     const fetchDocument = async url => {
@@ -44,6 +45,16 @@ const Schema = ({ url, includePath = [] }) => {
 
   return (
     <div className="schema-list">
+      {includePathDisplay && (
+        <div>
+          <input
+            type="checkbox"
+            checked={includesEnabled}
+            onChange={() => setInclude(includePathDisplay)}
+          />
+          {includePathDisplay}
+        </div>
+      )}
       <SchemaAttributes
         attributes={attributes}
         type={type}

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,6 +13,8 @@ export function toggleSetEntry(set, entry) {
   } else {
     set.add(entry);
   }
+
+  return set;
 }
 
 export function checkIncludesPath(include, includePath) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,3 +14,9 @@ export function toggleSetEntry(set, entry) {
     set.add(entry);
   }
 }
+
+export function checkIncludesPath(include, includePath) {
+  return includePath.length > 0
+    ? new Set(include).has(includePath.join('.'))
+    : true;
+}

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,0 +1,41 @@
+import { checkIncludesPath } from './utils';
+
+describe('Enabled if matches includes', () => {
+  test('Top level: No includes', () => {
+    expect(checkIncludesPath([], [])).toBe(true);
+  });
+
+  test('Top level: One include', () => {
+    expect(checkIncludesPath(['uid'], [])).toBe(true);
+  });
+
+  test('Top level: Multiple includes', () => {
+    expect(checkIncludesPath(['uid', 'node_type'], [])).toBe(true);
+  });
+
+  test('Relationship: No includes', () => {
+    expect(checkIncludesPath([], ['uid'])).toBe(false);
+  });
+
+  test('Relationship: matching include', () => {
+    expect(checkIncludesPath(['uid'], ['uid'])).toBe(true);
+  });
+
+  test('Relationship: mismatch include', () => {
+    expect(checkIncludesPath(['node_type'], ['uid'])).toBe(false);
+  });
+
+  test('Relationship: matching include plus other', () => {
+    expect(checkIncludesPath(['uid', 'node_type'], ['uid'])).toBe(true);
+  });
+
+  test('Relationship: matching deep include', () => {
+    expect(checkIncludesPath(['uid.roles'], ['uid', 'roles'])).toBe(true);
+  });
+
+  test('Relationship: mismatching deep include', () => {
+    expect(checkIncludesPath(['uid'], ['uid', 'user_picture', 'uid'])).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
This fixes the attributes enabled for top level, and enabled attributes for included resources.
Added a checkbox to "include" a relationship, this works as a toggle so they can be added or removed.
Multiple relationships can be included, as well as deeply nested relationships.

Fields are fixed as well so that fields from different resources are toggled separately.

example url: ```http://drupal.test/jsonapi/node/article?include=node_type,uid.roles&fields[node--article]=drupal_internal__nid&fields[node_type--node_type]=drupal_internal__type,name&fields[user_role--user_role]=drupal_internal__id```