### PR TITLE
Location based schema context

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.5",
     "dotenv-webpack": "^1.7.0",
+    "json-schema-ref-parser": "^6.1.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },

--- a/src/displayRaw.js
+++ b/src/displayRaw.js
@@ -1,9 +1,7 @@
 import React, { useState } from 'react';
 
-const DisplayRaw = ({ title, name, data, children }) => {
+const DisplayRaw = ({ title, name, document, children }) => {
   const [activeTab, setActiveTab] = useState(0);
-
-  const length = Array.isArray(data) ? data.length : Object.keys(data).length;
 
   const TabMenu = ({ title, id }) => (
     <li
@@ -16,7 +14,7 @@ const DisplayRaw = ({ title, name, data, children }) => {
 
   return (
     <div className={`pane ${name}`}>
-      {length > 0 && (
+      {document && (
         <>
           <ul className="tabs">
             <TabMenu id={0} title={title} />
@@ -29,7 +27,7 @@ const DisplayRaw = ({ title, name, data, children }) => {
           <div className={`tab ${activeTab === 1 ? 'tab__active' : ''}`}>
             <h2>Raw</h2>
             <div className="scrollable scrollable_x raw-results">
-              <pre>{JSON.stringify(data, null, '  ')}</pre>
+              <pre>{JSON.stringify(document, null, '  ')}</pre>
             </div>
           </div>
         </>

--- a/src/explorer-ui.js
+++ b/src/explorer-ui.js
@@ -7,7 +7,8 @@ import { LocationContext } from './location';
 const ExplorerUI = () => {
   const { locationUrl, document, onEntryPoint } = useContext(LocationContext);
   const [entryPointLinks, setEntryPointLinks] = useState({});
-  const parsedLinks = document && document.links ? Link.parseLinks(document.links) : {};
+  const parsedLinks =
+    document && document.links ? Link.parseLinks(document.links) : {};
 
   useEffect(() => {
     if (onEntryPoint) setEntryPointLinks(parsedLinks);

--- a/src/explorer-ui.js
+++ b/src/explorer-ui.js
@@ -7,7 +7,7 @@ import { LocationContext } from './location';
 const ExplorerUI = () => {
   const { locationUrl, document, onEntryPoint } = useContext(LocationContext);
   const [entryPointLinks, setEntryPointLinks] = useState({});
-  const parsedLinks = document.links ? Link.parseLinks(document.links) : {};
+  const parsedLinks = document && document.links ? Link.parseLinks(document.links) : {};
 
   useEffect(() => {
     if (onEntryPoint) setEntryPointLinks(parsedLinks);

--- a/src/lib/normalize.js
+++ b/src/lib/normalize.js
@@ -1,8 +1,8 @@
+import { extract } from "../utils";
+
 function getDefinitions(schema, definition, process = null) {
-  const $n = {};
-  return (((schema || $n).definitions || $n)[definition] || $n).properties
-    ? mapDefinitions(schema.definitions[definition].properties, process)
-    : [];
+  const extracted = extract(schema, (schema && schema.type === 'array' ? 'items.' : '') + `definitions.${definition}.properties`);
+  return extracted ? mapDefinitions(extracted, process) : [];
 }
 
 function findProperty(property, obj) {
@@ -26,17 +26,6 @@ export function mapDefinitions(definitions, process = null) {
 
 export function getRelationshipSchema(relationship) {
   return findProperty('describedBy', relationship);
-}
-
-export function getResourceRef(schema) {
-  const { data } = schema.definitions;
-  return data.hasOwnProperty('items') ? data.items.$ref : data.$ref;
-}
-
-export function getDescribedByUrl(describedBy) {
-  return describedBy.hasOwnProperty('href')
-    ? describedBy.href
-    : describedBy.const;
 }
 
 export const getAttributes = schema => getDefinitions(schema, 'attributes');

--- a/src/lib/normalize.test.js
+++ b/src/lib/normalize.test.js
@@ -2,7 +2,6 @@ import {
   getAttributes,
   getRelationships,
   getRelationshipSchema,
-  getResourceRef,
   mapDefinitions,
 } from './normalize';
 
@@ -385,20 +384,6 @@ const schemaNoProperties = {
   $id: 'http://drupal.test/jsonapi/menu/menu/resource/schema.json',
   definitions: {},
 };
-
-describe('Schema metadata', () => {
-  test('Get the resource $ref from a collection schema', () => {
-    expect(getResourceRef(schemaArticleCollection)).toBe(
-      'http://drupal.test/jsonapi/node/article/resource/schema.json',
-    );
-  });
-
-  test('Get the resource $ref from a related schema', () => {
-    expect(getResourceRef(schemaNodeTypeRelated)).toBe(
-      'http://drupal.test/jsonapi/node_type/node_type/resource/schema.json',
-    );
-  });
-});
 
 describe('Schema Attributes', () => {
   test('Extract attribute names from schema definitions', () => {

--- a/src/location.js
+++ b/src/location.js
@@ -10,7 +10,7 @@ const Location = ({ homeUrl, children }) => {
   // Set the location state to a parsed url and a compiled url.
   const [parsedUrl, setParsedUrl] = useState(parseJsonApiUrl(homeUrl));
   const [locationUrl, setLocationUrl] = useState(compileJsonApiUrl(parsedUrl));
-  const [document, setDocument] = useState({});
+  const [document, setDocument] = useState(null);
 
   // Takes a single query parameter and updates the parsed url.
   const updateQuery = param =>

--- a/src/relationship.js
+++ b/src/relationship.js
@@ -1,11 +1,11 @@
 import React, { useContext, useState } from 'react';
 
 import SchemaUI from './schema-ui';
-import { SchemaContext, Schema } from "./schema";
+import { SchemaContext, Schema } from './schema';
 
 const Relationship = ({ relationship }) => {
   const { forPath } = useContext(SchemaContext);
-  const [ showSchema, setShowSchema ] = useState(false);
+  const [showSchema, setShowSchema] = useState(false);
 
   return (
     <div>

--- a/src/relationship.js
+++ b/src/relationship.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
-import Schema from './schema';
+import SchemaUI from './schema-ui';
 import { getDescribedByUrl } from './lib/normalize';
 
 const Relationship = ({ relationship, includePath }) => {
@@ -22,7 +22,7 @@ const Relationship = ({ relationship, includePath }) => {
     <div>
       <h4>{relationship.name}</h4>
       {showSchema ? (
-        <Schema url={schemaUrl} includePath={includePath} />
+        <SchemaUI url={schemaUrl} includePath={includePath} />
       ) : (
         <button onClick={() => setShowSchema(true)}>
           load <em>{relationship.name}</em>

--- a/src/relationship.js
+++ b/src/relationship.js
@@ -1,28 +1,19 @@
-import React, { useState, useEffect } from 'react';
+import React, { useContext, useState } from 'react';
 
 import SchemaUI from './schema-ui';
-import { getDescribedByUrl } from './lib/normalize';
+import { SchemaContext, Schema } from "./schema";
 
-const Relationship = ({ relationship, includePath }) => {
-  const [schemaUrl, setSchemaUrl] = useState('');
-  const [showSchema, setShowSchema] = useState(false);
-
-  const loadMeta = () => {
-    if (relationship.value.hasOwnProperty('describedBy')) {
-      const { describedBy } = relationship.value;
-      setSchemaUrl(getDescribedByUrl(describedBy));
-    }
-  };
-
-  useEffect(() => {
-    loadMeta();
-  }, [relationship]);
+const Relationship = ({ relationship }) => {
+  const { forPath } = useContext(SchemaContext);
+  const [ showSchema, setShowSchema ] = useState(false);
 
   return (
     <div>
       <h4>{relationship.name}</h4>
       {showSchema ? (
-        <SchemaUI url={schemaUrl} includePath={includePath} />
+        <Schema forPath={[...forPath, relationship.name]}>
+          <SchemaUI />
+        </Schema>
       ) : (
         <button onClick={() => setShowSchema(true)}>
           load <em>{relationship.name}</em>

--- a/src/resource.js
+++ b/src/resource.js
@@ -4,6 +4,7 @@ import { LinkElement } from './link';
 import DisplayRaw from './displayRaw';
 import SchemaUI from './schema-ui';
 import { LocationContext } from './location';
+import { Schema } from "./schema";
 
 const Resource = ({ links }) => {
   const {
@@ -14,8 +15,7 @@ const Resource = ({ links }) => {
     clearFieldSet,
     setSort,
   } = useContext(LocationContext);
-  const { describedBy = null, ...resourceLinks } = links;
-  const schemaUrl = describedBy ? describedBy.href : '';
+  const { describedBy: _, ...resourceLinks } = links;
   const { data = [], included = [] } = document;
 
   return (
@@ -71,7 +71,9 @@ const Resource = ({ links }) => {
           </ul>
         </div>
         <div className="pane schema">
-          <SchemaUI url={schemaUrl} />
+          <Schema>
+            <SchemaUI />
+          </Schema>
         </div>
         <DisplayRaw title="Results" name="results" data={document}>
           <div>

--- a/src/resource.js
+++ b/src/resource.js
@@ -4,7 +4,7 @@ import { LinkElement } from './link';
 import DisplayRaw from './displayRaw';
 import SchemaUI from './schema-ui';
 import { LocationContext } from './location';
-import { Schema } from "./schema";
+import { Schema } from './schema';
 
 const Resource = ({ links }) => {
   const {

--- a/src/resource.js
+++ b/src/resource.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 
 import { LinkElement } from './link';
 import DisplayRaw from './displayRaw';
-import Schema from './schema';
+import SchemaUI from './schema-ui';
 import { LocationContext } from './location';
 
 const Resource = ({ links }) => {
@@ -71,7 +71,7 @@ const Resource = ({ links }) => {
           </ul>
         </div>
         <div className="pane schema">
-          <Schema url={schemaUrl} />
+          <SchemaUI url={schemaUrl} />
         </div>
         <DisplayRaw title="Results" name="results" data={document}>
           <div>

--- a/src/resource.js
+++ b/src/resource.js
@@ -16,7 +16,7 @@ const Resource = ({ links }) => {
     setSort,
   } = useContext(LocationContext);
   const { describedBy: _, ...resourceLinks } = links;
-  const { data = [], included = [] } = document;
+  const { data = [], included = [] } = document || {};
 
   return (
     <main>
@@ -75,7 +75,7 @@ const Resource = ({ links }) => {
             <SchemaUI />
           </Schema>
         </div>
-        <DisplayRaw title="Results" name="results" data={document}>
+        <DisplayRaw title="Results" name="results" document={document}>
           <div>
             <h3>Data</h3>
             <ul>

--- a/src/schema-parser.js
+++ b/src/schema-parser.js
@@ -48,29 +48,39 @@ export default class SchemaParser {
     const data = extract(document, 'data');
     if (forPath.length) {
       const [next, ...further] = forPath;
-      const extractIdentifiers = resourceObject => extract(resourceObject, `relationships.${next}.data`, []);
+      const extractIdentifiers = resourceObject =>
+        extract(resourceObject, `relationships.${next}.data`, []);
       const identifiers = Array.isArray(data)
         ? data.reduce((identifiers, item) => {
-          const extracted = extractIdentifiers(item);
-          return [...identifiers, ...(Array.isArray(extracted) ? extracted : [extracted])];
-        }, [])
+            const extracted = extractIdentifiers(item);
+            return [
+              ...identifiers,
+              ...(Array.isArray(extracted) ? extracted : [extracted]),
+            ];
+          }, [])
         : extractIdentifiers(data);
       const identified = item => {
         return Array.isArray(identifiers)
           ? identifiers.reduce((inIncludes, identifier) => {
-            return inIncludes || identifier.type === item.type && identifier.id === item.id;
-          }, false)
+              return (
+                inIncludes ||
+                (identifier.type === item.type && identifier.id === item.id)
+              );
+            }, false)
           : identifiers.type === item.type && identifiers.id === item.id;
       };
       const included = document.included || [];
-      const syntheticRelatedDocument = {data: included.filter(identified)};
+      const syntheticRelatedDocument = { data: included.filter(identified) };
       if (included.length) {
         syntheticRelatedDocument['included'] = included;
       }
       inferred = this.inferSchema(syntheticRelatedDocument, further);
     } else {
       if (Array.isArray(data)) {
-        data.forEach(item => inferred = this.buildInferenceFromResourceObject(item, forPath));
+        data.forEach(
+          item =>
+            (inferred = this.buildInferenceFromResourceObject(item, forPath)),
+        );
       } else {
         inferred = this.buildInferenceFromResourceObject(data, forPath);
       }
@@ -84,20 +94,27 @@ export default class SchemaParser {
     inferred['type'] = item.type;
     inferred['attributes'] = Object.keys(extract(item, 'attributes', {}))
       .reduce((inferred, name) => {
-        return [...inferred, {name}];
+        return [...inferred, { name }];
       }, previousInference.attributes || [])
       .reduce((deduplicated, field) => {
-        if (!deduplicated.reduce((has, previous) => has || previous.name === field.name, false)) {
+        if (
+          !deduplicated.reduce(
+            (has, previous) => has || previous.name === field.name,
+            false,
+          )
+        ) {
           deduplicated.push(field);
         }
         return deduplicated;
       }, []);
-    inferred['relationships'] = Object.keys(extract(item, 'relationships', {})).reduce((inferred, name) => {
-      return [...inferred, {name}];
+    inferred['relationships'] = Object.keys(
+      extract(item, 'relationships', {}),
+    ).reduce((inferred, name) => {
+      return [...inferred, { name }];
     }, previousInference.relationships || []);
     this.inferenceCache[inferred.type] = inferred;
     return this.inferenceCache[inferred.type];
-  };
+  }
 
   loadSchema(schemaId) {
     let schemaPromise;

--- a/src/schema-parser.js
+++ b/src/schema-parser.js
@@ -1,0 +1,55 @@
+import $RefParser from 'json-schema-ref-parser';
+import { getAttributes, getRelationships } from "./lib/normalize";
+import { extract } from './utils';
+
+export default class SchemaParser {
+
+  constructor() {
+    this.schemaCache = {};
+  }
+
+  parse(root, forPath = []) {
+    return typeof root === 'string'
+      ? this.loadSchema(root).then(schema => {
+        const dataSchema = extract(schema, 'definitions.data');
+        const type = extract(dataSchema, (dataSchema.type === 'array' ? 'items.' : '') + 'definitions.type.const');
+        const discovered = {
+          type,
+          attributes: getAttributes(dataSchema),
+          relationships: getRelationships(dataSchema),
+        };
+        if (forPath.length) {
+          const [ next, ...further ] = forPath;
+          const relationshipSchema = extract(dataSchema, (dataSchema.type === 'array' ? 'items.' : '') + 'definitions.relationships.properties');
+          const targetSchema = extract(relationshipSchema, `${next}.links.related.meta.linkParams.describedBy`.split('.').join('.properties.') + '.const');
+          return targetSchema ? this.parse(targetSchema, further) : null;
+        } else {
+          return discovered;
+        }
+      })
+      : SchemaParser.inferSchema(root);
+  }
+
+  static inferSchema(document) {
+    return Promise.resolve({});
+  }
+
+  loadSchema(schemaId) {
+    let schemaPromise;
+    if (!this.schemaCache.hasOwnProperty(schemaId)) {
+      const publish = (success, result) => this.schemaCache[schemaId].forEach(([resolve, reject]) => success ? resolve(result) : reject(result));
+      $RefParser.dereference(schemaId).then(result => {
+        publish(true, result);
+        this.schemaCache[schemaId] = result;
+      }).catch(result => publish(false, result));
+    }
+    if (!this.schemaCache.hasOwnProperty(schemaId) || Array.isArray(this.schemaCache[schemaId])) {
+      schemaPromise = new Promise((resolve, reject) => this.schemaCache[schemaId] = [...(this.schemaCache[schemaId]||[]), [resolve, reject]]);
+    }
+    else {
+      schemaPromise = Promise.resolve(this.schemaCache[schemaId]);
+    }
+    return schemaPromise;
+  }
+
+}

--- a/src/schema-parser.js
+++ b/src/schema-parser.js
@@ -80,14 +80,21 @@ export default class SchemaParser {
 
   buildInferenceFromResourceObject(item) {
     const inferred = {};
-    const previousInference = this.inferenceCache[inferred.type] || {};
+    const previousInference = this.inferenceCache[item.type] || {};
     inferred['type'] = item.type;
-    inferred['attributes'] = Object.keys(extract(item, 'attributes', {})).reduce((inferred, name) => {
-      return [...inferred, {name}];
-    }, previousInference.attributes || []);
+    inferred['attributes'] = Object.keys(extract(item, 'attributes', {}))
+      .reduce((inferred, name) => {
+        return [...inferred, {name}];
+      }, previousInference.attributes || [])
+      .reduce((deduplicated, field) => {
+        if (!deduplicated.reduce((has, previous) => has || previous.name === field.name, false)) {
+          deduplicated.push(field);
+        }
+        return deduplicated;
+      }, []);
     inferred['relationships'] = Object.keys(extract(item, 'relationships', {})).reduce((inferred, name) => {
       return [...inferred, {name}];
-    }, previousInference.attributes || []);
+    }, previousInference.relationships || []);
     this.inferenceCache[inferred.type] = inferred;
     return this.inferenceCache[inferred.type];
   };

--- a/src/schema-ui.js
+++ b/src/schema-ui.js
@@ -1,49 +1,21 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useContext } from 'react';
 
 import SchemaAttributes from './schemaAttributes';
 import SchemaRelationships from './schemaRelationships';
 
-import {
-  getAttributes,
-  getRelationships,
-  getResourceRef,
-} from './lib/normalize';
-import { request } from './lib/request';
-import { extract, checkIncludesPath } from './utils';
+import { checkIncludesPath } from './utils';
 import { LocationContext } from './location';
+import { SchemaContext } from "./schema";
 
-const SchemaUI = ({ url, includePath = [] }) => {
-  const [type, setType] = useState('');
-  const [attributes, setAttributes] = useState([]);
-  const [relationships, setRelationships] = useState([]);
+const SchemaUI = () => {
+  const { schema, forPath } = useContext(SchemaContext);
+  const { type = '', attributes = [], relationships = [] } = schema||{};
   const { include, toggleInclude } = useContext(LocationContext);
 
-  const includesEnabled = checkIncludesPath(include, includePath);
-  const includePathString = includePath.join('.');
+  const includesEnabled = checkIncludesPath(include, forPath);
+  const includePathString = forPath.join('.');
 
-  useEffect(() => {
-    const fetchDocument = async url => {
-      const result = await request(url);
-
-      if (result.hasOwnProperty('definitions')) {
-        const $ref = getResourceRef(result);
-
-        if ($ref) {
-          const meta = await request($ref);
-
-          setType(extract(meta, 'definitions.type.const', ''));
-          setAttributes(getAttributes(meta));
-          setRelationships(getRelationships(meta));
-        }
-      }
-    };
-
-    if (url && url !== '') {
-      fetchDocument(url);
-    }
-  }, [url]);
-
-  return (
+  return schema && (
     <div className="schema-list">
       {includePathString && (
         <div>
@@ -62,7 +34,6 @@ const SchemaUI = ({ url, includePath = [] }) => {
       />
       <SchemaRelationships
         relationships={relationships}
-        includePath={includePath}
       />
     </div>
   );

--- a/src/schema-ui.js
+++ b/src/schema-ui.js
@@ -5,37 +5,37 @@ import SchemaRelationships from './schemaRelationships';
 
 import { checkIncludesPath } from './utils';
 import { LocationContext } from './location';
-import { SchemaContext } from "./schema";
+import { SchemaContext } from './schema';
 
 const SchemaUI = () => {
   const { schema, forPath } = useContext(SchemaContext);
-  const { type = '', attributes = [], relationships = [] } = schema||{};
+  const { type = '', attributes = [], relationships = [] } = schema || {};
   const { include, toggleInclude } = useContext(LocationContext);
 
   const includesEnabled = checkIncludesPath(include, forPath);
   const includePathString = forPath.join('.');
 
-  return schema && (
-    <div className="schema-list">
-      {includePathString && (
-        <div>
-          <input
-            type="checkbox"
-            checked={includesEnabled}
-            onChange={() => toggleInclude(includePathString)}
-          />
-          {includePathString}
-        </div>
-      )}
-      <SchemaAttributes
-        attributes={attributes}
-        type={type}
-        includesEnabled={includesEnabled}
-      />
-      <SchemaRelationships
-        relationships={relationships}
-      />
-    </div>
+  return (
+    schema && (
+      <div className="schema-list">
+        {includePathString && (
+          <div>
+            <input
+              type="checkbox"
+              checked={includesEnabled}
+              onChange={() => toggleInclude(includePathString)}
+            />
+            {includePathString}
+          </div>
+        )}
+        <SchemaAttributes
+          attributes={attributes}
+          type={type}
+          includesEnabled={includesEnabled}
+        />
+        <SchemaRelationships relationships={relationships} />
+      </div>
+    )
   );
 };
 

--- a/src/schema-ui.js
+++ b/src/schema-ui.js
@@ -12,7 +12,7 @@ import { request } from './lib/request';
 import { extract, checkIncludesPath } from './utils';
 import { LocationContext } from './location';
 
-const Schema = ({ url, includePath = [] }) => {
+const SchemaUI = ({ url, includePath = [] }) => {
   const [type, setType] = useState('');
   const [attributes, setAttributes] = useState([]);
   const [relationships, setRelationships] = useState([]);
@@ -68,4 +68,4 @@ const Schema = ({ url, includePath = [] }) => {
   );
 };
 
-export default Schema;
+export default SchemaUI;

--- a/src/schema.js
+++ b/src/schema.js
@@ -11,9 +11,12 @@ const Schema = ({ forPath = [], children }) => {
   const [contextSchema, setContextSchema] = useState(null);
   const { document } = useContext(LocationContext);
   useEffect(() => {
-    schemaParser
-      .parse(extract(document, 'links.describedBy.href') || document, forPath)
-      .then(setContextSchema);
+    const root = extract(document, 'links.describedBy.href') || document;
+    if (root) {
+      schemaParser
+        .parse(root, forPath)
+        .then(setContextSchema);
+    }
   }, [document]);
   return (
     <SchemaContext.Provider value={{ schema: contextSchema, forPath }}>

--- a/src/schema.js
+++ b/src/schema.js
@@ -13,9 +13,7 @@ const Schema = ({ forPath = [], children }) => {
   useEffect(() => {
     const root = extract(document, 'links.describedBy.href') || document;
     if (root) {
-      schemaParser
-        .parse(root, forPath)
-        .then(setContextSchema);
+      schemaParser.parse(root, forPath).then(setContextSchema);
     }
   }, [document]);
   return (

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,0 +1,19 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import SchemaParser from "./schema-parser";
+import { extract } from "./utils";
+import {LocationContext} from "./location";
+
+const schemaParser = new SchemaParser();
+
+const SchemaContext = createContext({});
+
+const Schema = ({ forPath = [], children }) => {
+  const [ contextSchema, setContextSchema ] = useState(null);
+  const { document } = useContext(LocationContext);
+  useEffect(() => {
+    schemaParser.parse(extract(document, 'links.describedBy.href') || document, forPath).then(setContextSchema);
+  }, [document]);
+  return <SchemaContext.Provider value={{schema: contextSchema, forPath}}>{children}</SchemaContext.Provider>;
+};
+
+export { SchemaContext, Schema };

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,19 +1,25 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import SchemaParser from "./schema-parser";
-import { extract } from "./utils";
-import {LocationContext} from "./location";
+import SchemaParser from './schema-parser';
+import { extract } from './utils';
+import { LocationContext } from './location';
 
 const schemaParser = new SchemaParser();
 
 const SchemaContext = createContext({});
 
 const Schema = ({ forPath = [], children }) => {
-  const [ contextSchema, setContextSchema ] = useState(null);
+  const [contextSchema, setContextSchema] = useState(null);
   const { document } = useContext(LocationContext);
   useEffect(() => {
-    schemaParser.parse(extract(document, 'links.describedBy.href') || document, forPath).then(setContextSchema);
+    schemaParser
+      .parse(extract(document, 'links.describedBy.href') || document, forPath)
+      .then(setContextSchema);
   }, [document]);
-  return <SchemaContext.Provider value={{schema: contextSchema, forPath}}>{children}</SchemaContext.Provider>;
+  return (
+    <SchemaContext.Provider value={{ schema: contextSchema, forPath }}>
+      {children}
+    </SchemaContext.Provider>
+  );
 };
 
 export { SchemaContext, Schema };

--- a/src/schemaRelationships.js
+++ b/src/schemaRelationships.js
@@ -2,17 +2,14 @@ import React from 'react';
 
 import Relationship from './relationship';
 
-const SchemaRelationships = ({ relationships, includePath }) =>
+const SchemaRelationships = ({ relationships }) =>
   relationships.length > 0 ? (
     <div>
       <h3>Relationships</h3>
       <ul>
         {relationships.map((relationship, index) => (
           <li key={`schema-relationship-${index}`}>
-            <Relationship
-              relationship={relationship}
-              includePath={[...includePath, relationship.name]}
-            />
+            <Relationship relationship={relationship} />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
This gets the explorer ready for backends that do not have a schema (any existing JSON:API server since the spec says nothing about schema).

What this does is move schema parsing out of the schema UI component so that everything can be handled in one location. The most confusing part about the diff below is that I renamed `schema.js` to `schema-ui.js` and added a new `schema.js` file that does all the finagling to generate a schema for the UI component.

That separation of concerns should make it so that the `schema-ui.js` file doesn't need to care if the schema was provided by the server or if it was inferred by it.

I rewrote a lot of the parsing I had for schema to use the methods in `normalize.js` because they all had tests. The only things I removed from `normalize.js` were the functions for extracting references and `describedBy` URLs.

The last benefit I see from this direction is that we'll be able to wrap the filter component in a `<Schema>` element so that it also has access to the schema without duplicating any logic that used to be in `schema-ui.js`.

I'm leaving this as a draft to get your initial feedback @zrpnr and to have some very basic inferred schema working.