### PR TITLE
Infer schema from requested documents and remember relationships

### DIFF
--- a/src/displayRaw.js
+++ b/src/displayRaw.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-const DisplayRaw = ({ title, name, document, children }) => {
+const DisplayRaw = ({ title, name, responseDocument, children }) => {
   const [activeTab, setActiveTab] = useState(0);
 
   const TabMenu = ({ title, id }) => (
@@ -14,7 +14,7 @@ const DisplayRaw = ({ title, name, document, children }) => {
 
   return (
     <div className={`pane ${name}`}>
-      {document && (
+      {responseDocument && (
         <>
           <ul className="tabs">
             <TabMenu id={0} title={title} />
@@ -27,7 +27,7 @@ const DisplayRaw = ({ title, name, document, children }) => {
           <div className={`tab ${activeTab === 1 ? 'tab__active' : ''}`}>
             <h2>Raw</h2>
             <div className="scrollable scrollable_x raw-results">
-              <pre>{JSON.stringify(document, null, '  ')}</pre>
+              <pre>{JSON.stringify(responseDocument, null, '  ')}</pre>
             </div>
           </div>
         </>

--- a/src/explorer-ui.js
+++ b/src/explorer-ui.js
@@ -7,8 +7,7 @@ import { LocationContext } from './location';
 const ExplorerUI = () => {
   const { locationUrl, document, onEntryPoint } = useContext(LocationContext);
   const [entryPointLinks, setEntryPointLinks] = useState({});
-  const parsedLinks =
-    document && document.links ? Link.parseLinks(document.links) : {};
+  const parsedLinks = document ? document.getLinks() : {};
 
   useEffect(() => {
     if (onEntryPoint) setEntryPointLinks(parsedLinks);

--- a/src/explorer-ui.js
+++ b/src/explorer-ui.js
@@ -1,11 +1,11 @@
 import React, { useState, useEffect, useContext } from 'react';
 
-import { Link, LinkElement } from './link';
+import { LinkElement } from './link';
 import Resource from './resource';
 import { LocationContext } from './location';
 
 const ExplorerUI = () => {
-  const { locationUrl, document: responseDocument, onEntryPoint } = useContext(LocationContext);
+  const { locationUrl, responseDocument, onEntryPoint } = useContext(LocationContext);
   const [entryPointLinks, setEntryPointLinks] = useState({});
   const parsedLinks = responseDocument ? responseDocument.getLinks() : {};
 

--- a/src/explorer-ui.js
+++ b/src/explorer-ui.js
@@ -5,7 +5,9 @@ import Resource from './resource';
 import { LocationContext } from './location';
 
 const ExplorerUI = () => {
-  const { locationUrl, responseDocument, onEntryPoint } = useContext(LocationContext);
+  const { locationUrl, responseDocument, onEntryPoint } = useContext(
+    LocationContext,
+  );
   const [entryPointLinks, setEntryPointLinks] = useState({});
   const parsedLinks = responseDocument ? responseDocument.getLinks() : {};
 

--- a/src/explorer-ui.js
+++ b/src/explorer-ui.js
@@ -5,9 +5,9 @@ import Resource from './resource';
 import { LocationContext } from './location';
 
 const ExplorerUI = () => {
-  const { locationUrl, document, onEntryPoint } = useContext(LocationContext);
+  const { locationUrl, document: responseDocument, onEntryPoint } = useContext(LocationContext);
   const [entryPointLinks, setEntryPointLinks] = useState({});
-  const parsedLinks = document ? document.getLinks() : {};
+  const parsedLinks = responseDocument ? responseDocument.getLinks() : {};
 
   useEffect(() => {
     if (onEntryPoint) setEntryPointLinks(parsedLinks);

--- a/src/lib/document.js
+++ b/src/lib/document.js
@@ -39,7 +39,7 @@ export default class Document {
   }
 
   isEmptyDocument() {
-    return this.isErrorDocument() || ![this.raw.data].flat.length;
+    return this.isErrorDocument() || ![this.raw.data].flat().length;
   }
 
   isIndividualDocument() {

--- a/src/lib/document.js
+++ b/src/lib/document.js
@@ -1,0 +1,74 @@
+import {Link} from "../link";
+import ResourceObject from "./resource-object";
+import { extract } from "../utils";
+import SchemaParser from "../schema-parser";
+import { identifies } from "./resource-object";
+
+const schemaParser = new SchemaParser();
+
+export default class Document {
+
+  constructor({raw}) {
+    this.raw = raw;
+  }
+
+  static parse(raw) {
+    return new Document({raw});
+  }
+
+  getData() {
+    return this.getResourceObjects()
+      .filter(object => this.isCollectionDocument()
+        ? this.raw.data.some(identifies(object))
+        : identifies(object)(this.raw.data)
+      );
+  }
+
+  getIncluded() {
+    return this.getResourceObjects()
+      .filter(object => this.hasIncluded() && this.raw.included.some(identifies(object)))
+  }
+
+  getResourceObjects() {
+    if (this.isEmptyDocument()) {
+      return [];
+    }
+
+    const rawDataObjects = this.isCollectionDocument() ? this.raw.data : [this.raw.data];
+    const includedObjects = this.hasIncluded() ? this.raw.included : [];
+
+    return []
+      .concat(rawDataObjects)
+      .concat(includedObjects)
+      .map(raw => ResourceObject.parse(raw).withParentDocument(this));
+  }
+
+  getSchema(forPath = []) {
+    return schemaParser.parse(this, forPath);
+  }
+
+  getLinks() {
+    return Link.parseLinks(this.raw.links || {});
+  }
+
+  hasIncluded() {
+    return Array.isArray(this.raw.included);
+  }
+
+  isEmptyDocument() {
+    return this.isErrorDocument() || (this.isCollectionDocument() && !this.raw.data.length) || !this.raw.data;
+  }
+
+  isIndividualDocument() {
+    return !this.isErrorDocument() && !this.isCollectionDocument();
+  }
+
+  isCollectionDocument() {
+    return !this.isErrorDocument() && Array.isArray(this.raw.data);
+  }
+
+  isErrorDocument() {
+    return this.raw.errors;
+  }
+
+}

--- a/src/lib/resource-object.js
+++ b/src/lib/resource-object.js
@@ -14,8 +14,8 @@ export default class ResourceObject {
     return new ResourceObject({raw});
   }
 
-  withParentDocument(document) {
-    this.parentDocument = document;
+  withParentDocument(responseDocument) {
+    this.parentDocument = responseDocument;
     return this;
   }
 

--- a/src/lib/resource-object.js
+++ b/src/lib/resource-object.js
@@ -1,0 +1,56 @@
+import {Link} from "../link";
+import { extract } from '../utils'
+
+export const identifies = object => identifier => object.matches(identifier);
+
+export default class ResourceObject {
+
+  constructor({raw}) {
+    this.raw = raw;
+    this.parentDocument = null;
+  }
+
+  static parse(raw) {
+    return new ResourceObject({raw});
+  }
+
+  withParentDocument(document) {
+    this.parentDocument = document;
+    return this;
+  }
+
+  getType() {
+    return this.raw.type;
+  }
+
+  getID() {
+    return this.raw.id;
+  }
+
+  getAttributes() {
+    return this.raw.attributes || {};
+  }
+
+  getRelationships() {
+    return this.raw.relationships || {};
+  }
+
+  getRelated(fieldName) {
+    if (!this.parentDocument.hasIncluded()) {
+      return [];
+    }
+    const relationshipData = extract(this.raw, `relationships.${fieldName}.data`) || null;
+    return Array.isArray(relationshipData)
+      ? this.parentDocument.getIncluded().filter(object => relationshipData.some(identifies(object)))
+      : this.parentDocument.getIncluded().find(object => relationshipData && identifies(object)(relationshipData)) || null;
+  }
+
+  getLinks() {
+    return Link.parseLinks(this.raw.links || {});
+  }
+
+  matches({type, id}) {
+    return this.getType() === type && this.getID() === id;
+  }
+
+}

--- a/src/lib/resource-object.js
+++ b/src/lib/resource-object.js
@@ -1,8 +1,6 @@
 import {Link} from "../link";
 import { extract } from '../utils'
 
-export const identifies = object => identifier => object.matches(identifier);
-
 export default class ResourceObject {
 
   constructor({raw}) {
@@ -36,13 +34,9 @@ export default class ResourceObject {
   }
 
   getRelated(fieldName) {
-    if (!this.parentDocument.hasIncluded()) {
-      return [];
-    }
     const relationshipData = extract(this.raw, `relationships.${fieldName}.data`) || null;
-    return Array.isArray(relationshipData)
-      ? this.parentDocument.getIncluded().filter(object => relationshipData.some(identifies(object)))
-      : this.parentDocument.getIncluded().find(object => relationshipData && identifies(object)(relationshipData)) || null;
+    const relatedObjects = this.parentDocument.getIncluded().filter(object => [relationshipData].flat().some(identifies(object)));
+    return Array.isArray(relationshipData) ? relatedObjects : relatedObjects.pop();
   }
 
   getLinks() {
@@ -54,3 +48,5 @@ export default class ResourceObject {
   }
 
 }
+
+const identifies = object => identifier => object.matches(identifier);

--- a/src/lib/resource-object.js
+++ b/src/lib/resource-object.js
@@ -35,8 +35,8 @@ export default class ResourceObject {
 
   getRelated(fieldName) {
     const relationshipData = extract(this.raw, `relationships.${fieldName}.data`) || null;
-    const relatedObjects = this.parentDocument.getIncluded().filter(object => [relationshipData].flat().some(identifies(object)));
-    return Array.isArray(relationshipData) ? relatedObjects : relatedObjects.pop();
+    const relatedObjects = this.parentDocument.getIncluded().filter(object => relationshipData && [relationshipData].flat().some(identifies(object)));
+    return Array.isArray(relationshipData) ? relatedObjects : relatedObjects.pop() || null;
   }
 
   getLinks() {

--- a/src/location.js
+++ b/src/location.js
@@ -24,7 +24,7 @@ const Location = ({ homeUrl, children }) => {
   // If the parsed url is updated, compile it and update the location url.
   useEffect(() => setLocationUrl(compileJsonApiUrl(parsedUrl)), [parsedUrl]);
   useEffect(() => {
-    request(locationUrl).then(res => setDocument(Document.parse(res)))
+    request(locationUrl).then(res => setDocument(Document.parse(res)));
   }, [locationUrl]);
 
   // Extract and surface useful url components in the location context as
@@ -44,7 +44,8 @@ const Location = ({ homeUrl, children }) => {
         sort,
         fragment,
         onEntryPoint:
-          responseDocument && extract(responseDocument.getLinks(), 'self.href') === homeUrl,
+          responseDocument &&
+          extract(responseDocument.getLinks(), 'self.href') === homeUrl,
         setUrl: newLocationUrl => setParsedUrl(parseJsonApiUrl(newLocationUrl)),
         setFilter: newParam => updateQuery({ filter: newParam }),
         toggleField: (type, field) => {

--- a/src/location.js
+++ b/src/location.js
@@ -11,7 +11,7 @@ const Location = ({ homeUrl, children }) => {
   // Set the location state to a parsed url and a compiled url.
   const [parsedUrl, setParsedUrl] = useState(parseJsonApiUrl(homeUrl));
   const [locationUrl, setLocationUrl] = useState(compileJsonApiUrl(parsedUrl));
-  const [document, setDocument] = useState(null);
+  const [responseDocument, setDocument] = useState(null);
 
   // Takes a single query parameter and updates the parsed url.
   const updateQuery = param =>
@@ -37,14 +37,14 @@ const Location = ({ homeUrl, children }) => {
       value={{
         parsedUrl,
         locationUrl,
-        document,
+        responseDocument,
         filter,
         fields,
         include,
         sort,
         fragment,
         onEntryPoint:
-          document && extract(document.getLinks(), 'self.href') === homeUrl,
+          responseDocument && extract(responseDocument.getLinks(), 'self.href') === homeUrl,
         setUrl: newLocationUrl => setParsedUrl(parseJsonApiUrl(newLocationUrl)),
         setFilter: newParam => updateQuery({ filter: newParam }),
         toggleField: (type, field) => {

--- a/src/location.js
+++ b/src/location.js
@@ -3,6 +3,7 @@ import { extract, toggleSetEntry } from './utils';
 
 import { request } from './lib/request';
 import { parseJsonApiUrl, compileJsonApiUrl } from './lib/url';
+import Document from './lib/document';
 
 const LocationContext = createContext({});
 
@@ -23,7 +24,7 @@ const Location = ({ homeUrl, children }) => {
   // If the parsed url is updated, compile it and update the location url.
   useEffect(() => setLocationUrl(compileJsonApiUrl(parsedUrl)), [parsedUrl]);
   useEffect(() => {
-    request(locationUrl).then(setDocument);
+    request(locationUrl).then(res => setDocument(Document.parse(res)))
   }, [locationUrl]);
 
   // Extract and surface useful url components in the location context as
@@ -42,7 +43,8 @@ const Location = ({ homeUrl, children }) => {
         include,
         sort,
         fragment,
-        onEntryPoint: extract(document, 'links.self.href') === homeUrl,
+        onEntryPoint:
+          document && extract(document.getLinks(), 'self.href') === homeUrl,
         setUrl: newLocationUrl => setParsedUrl(parseJsonApiUrl(newLocationUrl)),
         setFilter: newParam => updateQuery({ filter: newParam }),
         toggleField: (type, field) => {

--- a/src/resource.js
+++ b/src/resource.js
@@ -76,33 +76,37 @@ const Resource = ({ links }) => {
             <SchemaUI />
           </Schema>
         </div>
-        <DisplayRaw title="Results" name="results" responseDocument={responseDocument && responseDocument.raw}>
+        <DisplayRaw
+          title="Results"
+          name="results"
+          responseDocument={responseDocument && responseDocument.raw}
+        >
           <div>
             <h3>Data</h3>
             <ul>
-              {data
-                .map((item, index) => (
-                  <li key={`data-item-${index}`}>
-                    {Object.keys(item.getAttributes()).map(key => (
-                      <p key={`data-item-attributes-${key}`}>
-                        <em>{key}:</em> {JSON.stringify(item.getAttributes()[key])}
-                      </p>
-                    ))}
-                  </li>
-                ))}
+              {data.map((item, index) => (
+                <li key={`data-item-${index}`}>
+                  {Object.keys(item.getAttributes()).map(key => (
+                    <p key={`data-item-attributes-${key}`}>
+                      <em>{key}:</em>{' '}
+                      {JSON.stringify(item.getAttributes()[key])}
+                    </p>
+                  ))}
+                </li>
+              ))}
             </ul>
             <h3>Included</h3>
             <ul>
-              {included
-                .map((item, index) => (
-                  <li key={`included-item-${index}`}>
-                    {Object.keys(item.getAttributes()).map(key => (
-                      <p key={`included-item-attributes-${key}`}>
-                        <em>{key}:</em> {JSON.stringify(item.getAttributes()[key])}
-                      </p>
-                    ))}
-                  </li>
-                ))}
+              {included.map((item, index) => (
+                <li key={`included-item-${index}`}>
+                  {Object.keys(item.getAttributes()).map(key => (
+                    <p key={`included-item-attributes-${key}`}>
+                      <em>{key}:</em>{' '}
+                      {JSON.stringify(item.getAttributes()[key])}
+                    </p>
+                  ))}
+                </li>
+              ))}
             </ul>
           </div>
         </DisplayRaw>

--- a/src/resource.js
+++ b/src/resource.js
@@ -8,7 +8,7 @@ import { Schema } from './schema';
 
 const Resource = ({ links }) => {
   const {
-    document,
+    responseDocument,
     fields,
     setInclude,
     toggleField,
@@ -16,8 +16,8 @@ const Resource = ({ links }) => {
     setSort,
   } = useContext(LocationContext);
   const { describedBy: _, ...resourceLinks } = links;
-  const data = document ? document.getData() : [];
-  const included = document ? document.getIncluded() : [];
+  const data = responseDocument ? responseDocument.getData() : [];
+  const included = responseDocument ? responseDocument.getIncluded() : [];
 
   return (
     <main>
@@ -76,7 +76,7 @@ const Resource = ({ links }) => {
             <SchemaUI />
           </Schema>
         </div>
-        <DisplayRaw title="Results" name="results" document={document}>
+        <DisplayRaw title="Results" name="results" responseDocument={responseDocument && responseDocument.raw}>
           <div>
             <h3>Data</h3>
             <ul>

--- a/src/resource.js
+++ b/src/resource.js
@@ -16,7 +16,8 @@ const Resource = ({ links }) => {
     setSort,
   } = useContext(LocationContext);
   const { describedBy: _, ...resourceLinks } = links;
-  const { data = [], included = [] } = document || {};
+  const data = document ? document.getData() : [];
+  const included = document ? document.getIncluded() : [];
 
   return (
     <main>
@@ -80,12 +81,11 @@ const Resource = ({ links }) => {
             <h3>Data</h3>
             <ul>
               {data
-                .filter(item => item.attributes)
                 .map((item, index) => (
                   <li key={`data-item-${index}`}>
-                    {Object.keys(item.attributes).map(key => (
+                    {Object.keys(item.getAttributes()).map(key => (
                       <p key={`data-item-attributes-${key}`}>
-                        <em>{key}:</em> {JSON.stringify(item.attributes[key])}
+                        <em>{key}:</em> {JSON.stringify(item.getAttributes()[key])}
                       </p>
                     ))}
                   </li>
@@ -94,12 +94,11 @@ const Resource = ({ links }) => {
             <h3>Included</h3>
             <ul>
               {included
-                .filter(item => item.attributes)
                 .map((item, index) => (
                   <li key={`included-item-${index}`}>
-                    {Object.keys(item.attributes).map(key => (
+                    {Object.keys(item.getAttributes()).map(key => (
                       <p key={`included-item-attributes-${key}`}>
-                        <em>{key}:</em> {JSON.stringify(item.attributes[key])}
+                        <em>{key}:</em> {JSON.stringify(item.getAttributes()[key])}
                       </p>
                     ))}
                   </li>

--- a/src/schema-parser.js
+++ b/src/schema-parser.js
@@ -60,14 +60,14 @@ export default class SchemaParser {
     }
   }
 
-  inferSchema(document, forPath) {
-    if (document.isEmptyDocument()) {
+  inferSchema(responseDocument, forPath) {
+    if (responseDocument.isEmptyDocument()) {
       return null;
     }
     let inferred;
     if (forPath.length) {
       const [next, ...further] = forPath;
-      const documentData = [document.getData()].flat().reduce((grouped, resourceObject) => {
+      const documentData = [responseDocument.getData()].flat().reduce((grouped, resourceObject) => {
         return Object.assign(grouped, {
           [resourceObject.getType()]: [...(grouped[resourceObject.getType()] || []), resourceObject],
         });
@@ -76,12 +76,12 @@ export default class SchemaParser {
         const relatedData = groupedData.flatMap(resourceObject => {
           return resourceObject.getRelated(next)
         }).reduce((raw, item) => raw.concat(item ? [item.raw] : []), []);
-        const included = document.getIncluded().map(item => item.raw);
+        const included = responseDocument.getIncluded().map(item => item.raw);
         const syntheticDocument = Document.parse({ data: relatedData, included });
         return this.mergeWithCachedInference(`${type}/${further.join('/')}`, this.inferSchema(syntheticDocument, further));
       }).reduce(this.mergeResourceObjectSchema);
     } else {
-      [document.getData()].flat().forEach(item => {
+      [responseDocument.getData()].flat().forEach(item => {
         inferred = this.buildInferenceFromResourceObject(item);
       });
     }

--- a/src/schema-ui.js
+++ b/src/schema-ui.js
@@ -16,26 +16,24 @@ const SchemaUI = () => {
   const includePathString = forPath.join('.');
 
   return (
-    schema && (
-      <div className="schema-list">
-        {includePathString && (
-          <div>
-            <input
-              type="checkbox"
-              checked={includesEnabled}
-              onChange={() => toggleInclude(includePathString)}
-            />
-            {includePathString}
-          </div>
-        )}
-        <SchemaAttributes
-          attributes={attributes}
-          type={type}
-          includesEnabled={includesEnabled}
-        />
-        <SchemaRelationships relationships={relationships} />
-      </div>
-    )
+    <div className="schema-list">
+      {includePathString && (
+        <div>
+          <input
+            type="checkbox"
+            checked={includesEnabled}
+            onChange={() => toggleInclude(includePathString)}
+          />
+          {includePathString}
+        </div>
+      )}
+      <SchemaAttributes
+        attributes={attributes}
+        type={type}
+        includesEnabled={includesEnabled}
+      />
+      <SchemaRelationships relationships={relationships} />
+    </div>
   );
 };
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -4,11 +4,11 @@ import { LocationContext } from './location';
 const SchemaContext = createContext({});
 
 const Schema = ({ forPath = [], children }) => {
-  const { document } = useContext(LocationContext);
+  const { responseDocument } = useContext(LocationContext);
   const [contextSchema, setContextSchema] = useState(null);
   useEffect(() => {
-    if (document) document.getSchema(forPath).then(setContextSchema);
-  }, [document]);
+    if (responseDocument) responseDocument.getSchema(forPath).then(setContextSchema);
+  }, [responseDocument]);
   return (
     <SchemaContext.Provider value={{ schema: contextSchema, forPath }}>
       {children}

--- a/src/schema.js
+++ b/src/schema.js
@@ -7,7 +7,8 @@ const Schema = ({ forPath = [], children }) => {
   const { responseDocument } = useContext(LocationContext);
   const [contextSchema, setContextSchema] = useState(null);
   useEffect(() => {
-    if (responseDocument) responseDocument.getSchema(forPath).then(setContextSchema);
+    if (responseDocument)
+      responseDocument.getSchema(forPath).then(setContextSchema);
   }, [responseDocument]);
   return (
     <SchemaContext.Provider value={{ schema: contextSchema, forPath }}>

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,20 +1,13 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import SchemaParser from './schema-parser';
-import { extract } from './utils';
 import { LocationContext } from './location';
-
-const schemaParser = new SchemaParser();
 
 const SchemaContext = createContext({});
 
 const Schema = ({ forPath = [], children }) => {
-  const [contextSchema, setContextSchema] = useState(null);
   const { document } = useContext(LocationContext);
+  const [contextSchema, setContextSchema] = useState(null);
   useEffect(() => {
-    const root = extract(document, 'links.describedBy.href') || document;
-    if (root) {
-      schemaParser.parse(root, forPath).then(setContextSchema);
-    }
+    if (document) document.getSchema(forPath).then(setContextSchema);
   }, [document]);
   return (
     <SchemaContext.Provider value={{ schema: contextSchema, forPath }}>


### PR DESCRIPTION
This enriches the way schemas are generated when an explicit schema is not available.

If a document is given to the schema parser that has a sparse fieldset, it will strip the `fields` query parameter out of the URL and re-request another response document. Then, it will use that response's data so that a more complete schema can be generated.

This also creates a cache of inferred schemas for relationships, e.g. an example cache key might be `node--article/uid/user_picture`, which would return the schema for the resource identified by that relationship. This is important for showing schemas if a sparse fieldset is added after the fact or an include is removed.

To test this, you should disable the `jsonapi_schema` module, rebuild Drupal's cache _and_ open the chrome inspector and check "Disable cache" before refreshing the explorer. If you don't disable your browsers cache, it will still use cached responses from your local Drupal instance (Cmd+Shift+R only clears the cache for the current origin (e.g. `localhost:8080`) and not the cache for cross-origin requests; this has bitten me a few times).