### PR TITLE
Sets up minimal JSON highlighting

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>JSON:API Explorer</title>
   <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet">
+  <link href="https://codemirror.net/lib/codemirror.css" rel="stylesheet">
+  <link href="https://codemirror.net/addon/fold/foldgutter.css" rel="stylesheet">
+  <link href="https://codemirror.net/addon/fold/foldgutter.css" rel="stylesheet">
+  <link href="https://codemirror.net/addon/scroll/simplescrollbars.css" rel="stylesheet">
   <style>
 
     :root {
@@ -151,7 +155,6 @@
     }
 
     .raw-results {
-      margin: .5rem;
       max-width: 38vw;
     }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@babel/runtime": "^7.4.5",
+    "codemirror": "^5.47.0",
     "dotenv-webpack": "^1.7.0",
     "json-schema-ref-parser": "^6.1.0",
     "react": "^16.8.6",

--- a/src/code-mirror.js
+++ b/src/code-mirror.js
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+
+import CodeMirrorEditor from 'codemirror/lib/codemirror';
+import 'codemirror/mode/javascript/javascript';
+import 'codemirror/addon/display/autorefresh';
+import 'codemirror/addon/fold/brace-fold';
+import 'codemirror/addon/fold/foldcode';
+import 'codemirror/addon/fold/foldgutter';
+import 'codemirror/addon/scroll/simplescrollbars';
+
+const CodeMirror = ({code}) => {
+  const [ codeElem, setCodeElem ] = useState(null);
+  const [ codeMirror, setCodeMirror ] = useState(null);
+
+  useEffect(() => {
+    if (codeElem) {
+      if (!codeMirror) {
+        const codeMirror = CodeMirrorEditor(codeElem, {
+          value: code,
+          mode: 'application/ld+json',
+          readOnly: true,
+          lineWrapping: false,
+          lineNumbers: true,
+          foldGutter: true,
+          autoRefresh: true,
+          gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
+          scrollbarStyle: 'simple',
+        });
+        setCodeMirror(codeMirror);
+      } else {
+        codeMirror.setValue(code);
+      }
+    }
+  }, [codeElem, code]);
+
+  return (
+    <div ref={setCodeElem} className="raw-results" />
+  );
+};
+
+export default CodeMirror;

--- a/src/displayRaw.js
+++ b/src/displayRaw.js
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+
+import CodeMirrorElem from './code-mirror';
 
 const DisplayRaw = ({ title, name, responseDocument, children }) => {
   const [activeTab, setActiveTab] = useState(0);
@@ -26,9 +28,7 @@ const DisplayRaw = ({ title, name, responseDocument, children }) => {
           </div>
           <div className={`tab ${activeTab === 1 ? 'tab__active' : ''}`}>
             <h2>Raw</h2>
-            <div className="scrollable scrollable_x raw-results">
-              <pre>{JSON.stringify(responseDocument, null, '  ')}</pre>
-            </div>
+            <CodeMirrorElem code={JSON.stringify(document, null, '  ')}/>
           </div>
         </>
       )}


### PR DESCRIPTION
This PR sets up very minimal JSON highlighting.

The CodeMirror project has all kinds of neat features that we could use. You can use it to create custom behaviors when a user clicks on elements of text.

I'm leaving this as draft because I don't like using the CSS hosted on codemirror.net. The same CSS files were downloaded to the project when I ran `npm install`, but I'm not sure how to include them in the "right" way. @zrpnr, can you help me with that?