### PR TITLE
Cache schema per resource regardless of filters

### DIFF
--- a/src/schema-parser.js
+++ b/src/schema-parser.js
@@ -25,13 +25,14 @@ export default class SchemaParser {
     const selfURL = extract(links, 'self.href');
     const parsedSelfURL = parseJsonApiUrl(selfURL);
     if (Object.keys(parsedSelfURL.query.fields).length) {
-      parsedSelfURL.query.fields = [];
+      const completeFieldsetUrl = Object.assign({}, parsedSelfURL, {query: Object.assign({}, parsedSelfURL.query, {fields: []})});
       return this.parse(
-        Document.parse(await request(compileJsonApiUrl(parsedSelfURL))),
+        Document.parse(await request(compileJsonApiUrl(completeFieldsetUrl))),
         forPath,
       );
     }
-    return this.inferSchema(root, forPath);
+    const baseResourceURL = compileJsonApiUrl(Object.assign({}, parsedSelfURL, {protocol: 'inferred:', query: {}}));
+    return this.mergeWithCachedInference(baseResourceURL, this.inferSchema(root, forPath));
   }
 
   parseSchema(schema, forPath) {

--- a/src/schema-parser.js
+++ b/src/schema-parser.js
@@ -32,7 +32,8 @@ export default class SchemaParser {
       );
     }
     const baseResourceURL = compileJsonApiUrl(Object.assign({}, parsedSelfURL, {protocol: 'inferred:', query: {}}));
-    return this.mergeWithCachedInference(baseResourceURL, this.inferSchema(root, forPath));
+    const inferredSchema = this.inferSchema(root, forPath);
+    return !forPath.length ? this.mergeWithCachedInference(baseResourceURL, inferredSchema) : inferredSchema;;
   }
 
   parseSchema(schema, forPath) {


### PR DESCRIPTION
@zrpnr pointed out in Slack that the inferred schema would disappear if a filter caused an empty result. This keeps a cache of the schema for each resource without regard for the query string (esp. filters).