### PR TITLE
Remove empty filters from url before compile step to avoid flash of 0…

### DIFF
--- a/src/location.js
+++ b/src/location.js
@@ -1,5 +1,5 @@
 import React, { createContext, useState, useEffect, useReducer } from 'react';
-import { extract, toggleSetEntry } from './utils';
+import { extract, toggleSetEntry, removeEmpty } from './utils';
 
 import { request } from './lib/request';
 import { parseJsonApiUrl, compileJsonApiUrl } from './lib/url';
@@ -52,7 +52,7 @@ const Location = ({ homeUrl, children }) => {
     setUrl(
       compileJsonApiUrl(
         Object.assign({}, parsedUrl, {
-          query: Object.assign({}, parsedUrl.query, param),
+          query: Object.assign({}, parsedUrl.query, removeEmpty(param)),
         }),
       ),
     );

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,19 @@ export function extract(obj, path, dflt) {
   return path.split('.').reduce((obj, key) => (obj || $n)[key], obj) || dflt;
 }
 
+export function removeEmpty(value) {
+  let obj = { ...value };
+  Object.entries(obj).forEach(([key, val]) => {
+    if (val && typeof val === 'object') {
+      obj[key] = removeEmpty(val);
+    } else if (val === null || val === '') {
+      delete obj[key];
+    }
+  });
+
+  return obj;
+}
+
 export function isEmpty(value) {
   if (Set.prototype.isPrototypeOf(value)) {
     return !value.size;

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,4 +1,4 @@
-import { checkIncludesPath, isEmpty } from './utils';
+import { checkIncludesPath, isEmpty, removeEmpty } from './utils';
 
 describe('Enabled if matches includes', () => {
   test('Top level: No includes', () => {
@@ -54,5 +54,28 @@ describe('Check if different type variables are empty', () => {
   test('Sets are empty', () => {
     expect(isEmpty(new Set())).toBe(true);
     expect(isEmpty(new Set(['foo']))).toBe(false);
+  });
+});
+
+describe('Remove empty properties from object', () => {
+  test('Empty object is returned the same', () => {
+    expect(removeEmpty({})).toEqual({});
+    expect(removeEmpty({ filter: {} })).toEqual({ filter: {} });
+  });
+
+  test('Object with blank property is returned without it', () => {
+    expect(removeEmpty({ filter: { drupal_internal__id: '' } })).toEqual({
+      filter: {},
+    });
+  });
+
+  test('Object with non-blank properties are returned with them', () => {
+    expect(removeEmpty({ filter: { status: '1' } })).toEqual({
+      filter: { status: '1' },
+    });
+
+    expect(
+      removeEmpty({ filter: { drupal_internal__id: '', status: '1' } }),
+    ).toEqual({ filter: { status: '1' } });
   });
 });


### PR DESCRIPTION
… results

Quick fix to the flash of 0 results from an empty filter, more noticeable with an inferred schema as that currently drops out as well until a filter value is applied.