### PR TITLE
Fix removeEmpty to ignore Array and Set

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,9 +6,12 @@ export function extract(obj, path, dflt) {
 export function removeEmpty(value) {
   let obj = { ...value };
   Object.entries(obj).forEach(([key, val]) => {
-    if (val && typeof val === 'object') {
-      obj[key] = removeEmpty(val);
-    } else if (val === null || val === '') {
+    if (val && !Set.prototype.isPrototypeOf(val) && !Array.isArray(val)) {
+      if (typeof val === 'object') {
+        obj[key] = removeEmpty(val);
+      }
+    }
+    else if (val === null || val === '') {
       delete obj[key];
     }
   });

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -78,4 +78,16 @@ describe('Remove empty properties from object', () => {
       removeEmpty({ filter: { drupal_internal__id: '', status: '1' } }),
     ).toEqual({ filter: { status: '1' } });
   });
+
+  test('Object with sets are removed unchanged', () => {
+    expect(
+      removeEmpty({ fields: { 'node--article': new Set(['title']) } }),
+    ).toEqual({ fields: { 'node--article': new Set(['title']) } });
+  });
+
+  test('Object with arrays are removed unchanged', () => {
+    expect(
+      removeEmpty({ include: ['uid'] }),
+    ).toEqual({ include: ['uid'] });
+  });
 });


### PR DESCRIPTION
This function was breaking fields and include. Fixed by ignoring Set and Array.