### PR TITLE
Add a form so that any server can be used

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,15 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Location } from './contexts/location';
 import ExplorerUI from './components/explorer-ui';
-
-const homeUrl = process.env.TOP_LEVEL;
+import LocationBar from "./components/location-ui";
 
 const App = () => {
+  const [ landingUrl, setLandingUrl ] = useState(new URL(document.location.href).searchParams.get('location') || '');
+
   return (
-    <Location homeUrl={homeUrl}>
-      <ExplorerUI />
-    </Location>
+    <div className="container">
+      {landingUrl ? (
+        <Location landingUrl={landingUrl}>
+          <ExplorerUI />
+        </Location>
+      ) : (
+        <header>
+          <h1 className="app-title">JSON:API <span className="subtitle">Explorer</span></h1>
+          <LocationBar onNewUrl={setLandingUrl} value={landingUrl}/>
+        </header>
+      )}
+    </div>
   );
 };
 

--- a/src/components/explorer-ui.js
+++ b/src/components/explorer-ui.js
@@ -1,38 +1,32 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useContext } from 'react';
 
 import { LinkElement } from './link';
 import Resource from './resource';
 import { LocationContext } from '../contexts/location';
+import LocationBar from "./location-ui";
 
 const ExplorerUI = () => {
-  const { locationUrl, responseDocument, onEntryPoint } = useContext(LocationContext);
-  const [entryPointLinks, setEntryPointLinks] = useState({});
-  const parsedLinks = responseDocument ? responseDocument.getLinks() : {};
-
-  useEffect(() => {
-    if (onEntryPoint) setEntryPointLinks(parsedLinks);
-  }, [onEntryPoint]);
+  const { locationUrl, setUrl, entrypointDocument } = useContext(LocationContext);
+  const entrypointLinks = entrypointDocument ? entrypointDocument.getLinks() : {};
 
   return (
-    <div className="container">
+    <>
       <header>
         <h1 className="app-title">JSON:API <span className="subtitle">Explorer</span></h1>
-        <div className="location">
-          <div className="query-url">{locationUrl}</div>
-        </div>
+        <LocationBar onNewUrl={setUrl} value={locationUrl}/>
       </header>
       <nav className="resourceLinks">
         <div className="resourceLinks__location">Top Level</div>
         <ul className="resourceLinks__nav">
-          {Object.keys(entryPointLinks).map((key, index) => (
+          {Object.keys(entrypointLinks).map((key, index) => (
             <li key={`resource-link-${index}`} className="resourceLinks__link">
-              <LinkElement link={entryPointLinks[key]} />
+              <LinkElement link={entrypointLinks[key]} />
             </li>
           ))}
         </ul>
       </nav>
       <Resource />
-    </div>
+    </>
   );
 };
 

--- a/src/components/location-ui/index.js
+++ b/src/components/location-ui/index.js
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+
+const LocationBar = ({onNewUrl, value = ''}) => {
+  const [inputUrl, setInputUrl] = useState(value);
+
+  useEffect(() => setInputUrl(value), [value]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    inputUrl.length && onNewUrl(inputUrl);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="location">
+      <input
+        type="url"
+        className="query-url"
+        placeholder="Enter a JSON:API server URL to begin exploring... e.g. https://example.com/api"
+        value={inputUrl}
+        onChange={(e) => setInputUrl(e.target.value)}
+      />
+    </form>
+  );
+};
+
+export default LocationBar;

--- a/src/components/resource.js
+++ b/src/components/resource.js
@@ -10,8 +10,8 @@ import ResultUI from "./result-ui";
 import {LocationContext} from "../contexts/location";
 
 const Resource = () => {
-  const { responseDocument, onEntryPoint } = useContext(LocationContext);
-  const { describedBy: _, ...resourceLinks } = !onEntryPoint && responseDocument ? responseDocument.getLinks() : {};
+  const { responseDocument } = useContext(LocationContext);
+  const { describedBy: _, ...resourceLinks } = responseDocument ? responseDocument.getLinks() : {};
 
   return (
     <main>

--- a/src/lib/url/url.js
+++ b/src/lib/url/url.js
@@ -1,5 +1,8 @@
-const queryParams = ['include', 'filter', 'fields', 'sort'];
 import { isEmpty } from '../../utils';
+
+const entrypointPath = process.env.ENTRYPOINT_PATH;
+
+const queryParams = ['include', 'filter', 'fields', 'sort'];
 
 export const parseListParameter = value => {
   return value ? value.split(',') : [];
@@ -136,10 +139,10 @@ export const parseJsonApiUrl = fromUrl => {
 export const compileJsonApiUrl = ({
   protocol,
   host,
-  port,
-  path,
-  query,
-  fragment,
+  port = '',
+  path = '',
+  query = {},
+  fragment = '',
 }) => {
   const queryString = queryParams
     .filter(name => query[name] && !isEmpty(query[name]))
@@ -149,4 +152,9 @@ export const compileJsonApiUrl = ({
   return `${protocol}//${host}${port.length ? ':' + port : ''}${path}${
     fragment.length ? '#' + fragment : ''
   }${queryString.length ? '?' + queryString : ''}`;
+};
+
+export const getEntryPointForUrl = (url) => {
+  const {protocol, host, port} = parseJsonApiUrl(url);
+  return compileJsonApiUrl({protocol, host, port, path: entrypointPath});
 };


### PR DESCRIPTION
This adds an (ugly) form to the first screen that should receive the URL of a JSON:API endpoint to explore and also fixes the `location` query parameter so that the explorer URL can be used directly (without this change, the app will always redirect to `/jsonapi` on first load).

@zrpnr, I could use your help with the styling of that landing page ofc ;)