### PR TITLE
Change `document` to `responseDocument` in display-raw.js; it was previously missed in a rename.

### DIFF
--- a/src/components/result-ui/display-raw.js
+++ b/src/components/result-ui/display-raw.js
@@ -28,7 +28,7 @@ const DisplayRaw = ({ title, name, responseDocument, children }) => {
           </div>
           <div className={`tab ${activeTab === 1 ? 'tab__active' : ''}`}>
             <h2>Raw</h2>
-            <CodeMirrorElem code={JSON.stringify(document, null, '  ')}/>
+            <CodeMirrorElem code={JSON.stringify(responseDocument, null, '  ')}/>
           </div>
         </>
       )}


### PR DESCRIPTION
title says it all.

this is why the raw results aren't properly displayed in the JSON viewer.