### PR TITLE
Move schema ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "prettier": "1.17.1",
     "react-hot-loader": "^4.8.7",
     "sass-loader": "^7.1.0",
+    "svg-url-loader": "^2.3.3",
     "webpack": "^4.32.0",
     "webpack-cli": "^3.3.2",
     "webpack-dev-server": "^3.4.1"

--- a/src/components/explorer-ui.js
+++ b/src/components/explorer-ui.js
@@ -65,7 +65,7 @@ const ExplorerUI = () => {
         </div>
         {loadedSchemas.map((loaded, index) => (
           <SchemaMenu
-            key={`schema-menu-${loaded.forPath.join('.')}`}
+            key={`schema-menu-${[schema.type, ...loaded.forPath].join('.')}`}
             forPath={loaded.forPath}
             load={loadNext}
             back={() => setActiveMenu(index)}

--- a/src/components/explorer-ui.js
+++ b/src/components/explorer-ui.js
@@ -8,6 +8,7 @@ import SchemaMenu from './schema-ui/schema-menu';
 import useSchema from '../hooks/use-schema';
 
 const ExplorerUI = () => {
+  const schema = useSchema([]);
   const [activeMenu, setActiveMenu] = useState(0);
   const [loadedSchemas, setLoadedSchemas] = useState([]);
 
@@ -17,8 +18,6 @@ const ExplorerUI = () => {
   const entrypointLinks = entrypointDocument
     ? entrypointDocument.getLinks()
     : {};
-
-  const schema = useSchema([]);
 
   const loadNext = forPath => {
     // forPath length corresponds to array depth.

--- a/src/components/explorer-ui.js
+++ b/src/components/explorer-ui.js
@@ -1,17 +1,45 @@
-import React, { useContext } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 
 import { LinkElement } from './link';
 import Resource from './resource';
 import { LocationContext } from '../contexts/location';
 import LocationBar from './location-ui';
+import SchemaMenu from './schema-ui/schema-menu';
+import useSchema from '../hooks/use-schema';
 
 const ExplorerUI = () => {
+  const [activeMenu, setActiveMenu] = useState(0);
+  const [loadedSchemas, setLoadedSchemas] = useState([]);
+
   const { locationUrl, setUrl, entrypointDocument } = useContext(
     LocationContext,
   );
   const entrypointLinks = entrypointDocument
     ? entrypointDocument.getLinks()
     : {};
+
+  const schema = useSchema([]);
+
+  const loadNext = forPath => {
+    // forPath length corresponds to array depth.
+    const loaded = loadedSchemas.slice(0,forPath.length);
+    setLoadedSchemas([...loaded, { forPath }]);
+  };
+
+  useEffect(() => {
+    const style = document.documentElement.style;
+    style.setProperty('--nav-offset', activeMenu);
+  }, [activeMenu]);
+
+  useEffect(() => {
+    setActiveMenu(loadedSchemas.length);
+  }, [loadedSchemas]);
+
+  useEffect(() => {
+    if (schema) {
+      loadNext([]);
+    }
+  }, [schema]);
 
   return (
     <>
@@ -21,15 +49,29 @@ const ExplorerUI = () => {
         </h1>
         <LocationBar onNewUrl={setUrl} value={locationUrl} />
       </header>
-      <nav className="resourceLinks">
-        <div className="resourceLinks__location">Top Level</div>
-        <ul className="resourceLinks__nav">
-          {Object.keys(entrypointLinks).map((key, index) => (
-            <li key={`resource-link-${index}`} className="resourceLinks__link">
-              <LinkElement link={entrypointLinks[key]} />
-            </li>
-          ))}
-        </ul>
+      <nav className="menu">
+        <div className="menu__container">
+          <div className="menu__location">Top Level</div>
+          <ul className="menu__nav">
+            {Object.keys(entrypointLinks).map((key, index) => (
+              <li key={`resource-link-${index}`} className="menu__link">
+                <LinkElement
+                  link={entrypointLinks[key]}
+                  next={() => setActiveMenu(1)}
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
+        {loadedSchemas.map((loaded, index) => (
+          <SchemaMenu
+            key={`schema-menu-${loaded.forPath.join('.')}`}
+            forPath={loaded.forPath}
+            load={loadNext}
+            back={() => setActiveMenu(index)}
+            next={() => setActiveMenu(index + 1)}
+          />
+        ))}
       </nav>
       <Resource />
     </>

--- a/src/components/explorer-ui.js
+++ b/src/components/explorer-ui.js
@@ -10,7 +10,7 @@ import useSchema from '../hooks/use-schema';
 const ExplorerUI = () => {
   const schema = useSchema([]);
   const [activeMenu, setActiveMenu] = useState(0);
-  const [loadedSchemas, setLoadedSchemas] = useState([]);
+  const [loadedMenus, setLoadedMenus] = useState([]);
 
   const { locationUrl, setUrl, entrypointDocument } = useContext(
     LocationContext,
@@ -21,8 +21,8 @@ const ExplorerUI = () => {
 
   const loadNext = forPath => {
     // forPath length corresponds to array depth.
-    const loaded = loadedSchemas.slice(0, forPath.length);
-    setLoadedSchemas([...loaded, { forPath }]);
+    const loaded = loadedMenus.slice(0, forPath.length);
+    setLoadedMenus([...loaded, { forPath }]);
   };
 
   useEffect(() => {
@@ -31,8 +31,8 @@ const ExplorerUI = () => {
   }, [activeMenu]);
 
   useEffect(() => {
-    setActiveMenu(loadedSchemas.length);
-  }, [loadedSchemas]);
+    setActiveMenu(loadedMenus.length);
+  }, [loadedMenus]);
 
   useEffect(() => {
     if (schema) {
@@ -64,7 +64,7 @@ const ExplorerUI = () => {
             ))}
           </ul>
         </div>
-        {loadedSchemas.map((loaded, index) => (
+        {loadedMenus.map((loaded, index) => (
           <SchemaMenu
             key={`schema-menu-${[schema.type, ...loaded.forPath].join('.')}`}
             forPath={loaded.forPath}

--- a/src/components/explorer-ui.js
+++ b/src/components/explorer-ui.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useContext } from 'react';
 
-import { LinkElement } from './link';
+import { MenuLinkElement } from './link';
 import Resource from './resource';
 import { LocationContext } from '../contexts/location';
 import LocationBar from './location-ui';
@@ -22,7 +22,7 @@ const ExplorerUI = () => {
 
   const loadNext = forPath => {
     // forPath length corresponds to array depth.
-    const loaded = loadedSchemas.slice(0,forPath.length);
+    const loaded = loadedSchemas.slice(0, forPath.length);
     setLoadedSchemas([...loaded, { forPath }]);
   };
 
@@ -51,11 +51,13 @@ const ExplorerUI = () => {
       </header>
       <nav className="menu">
         <div className="menu__container">
-          <div className="menu__location">Top Level</div>
+          <div className="menu__location">
+            <span className="menu__location_title">Top Level</span>
+          </div>
           <ul className="menu__nav">
             {Object.keys(entrypointLinks).map((key, index) => (
               <li key={`resource-link-${index}`} className="menu__link">
-                <LinkElement
+                <MenuLinkElement
                   link={entrypointLinks[key]}
                   next={() => setActiveMenu(1)}
                 />

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -21,7 +21,19 @@ class Link {
   }
 }
 
-const LinkElement = ({ link, next }) => {
+const LinkElement = ({ link }) => {
+  const location = useContext(LocationContext);
+  return (
+    <button
+      className={`${location.locationUrl === link.href ? 'active' : ''}`}
+      onClick={() => location.setUrl(link.href)}
+    >
+      <span className="link__title">{link.text}</span>
+    </button>
+  );
+};
+
+const MenuLinkElement = ({ link, next }) => {
   const location = useContext(LocationContext);
   const handleClick = () => {
     location.setUrl(link.href);
@@ -30,16 +42,18 @@ const LinkElement = ({ link, next }) => {
 
   return (
     <button
-      className={`${location.locationUrl === link.href ? 'active' : ''}`}
+      className={`link--next ${
+        location.locationUrl === link.href ? 'active' : ''
+      }`}
       onClick={handleClick}
     >
       {link.title ? (
-        <>
+        <span>
           <span className="link__title link__title--readable">
             {link.title}
           </span>
           <span className="link__text link__text--machine">{link.text}</span>
-        </>
+        </span>
       ) : (
         <span className="link__title">{link.text}</span>
       )}
@@ -47,4 +61,4 @@ const LinkElement = ({ link, next }) => {
   );
 };
 
-export { Link, LinkElement };
+export { Link, LinkElement, MenuLinkElement };

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -21,12 +21,17 @@ class Link {
   }
 }
 
-const LinkElement = ({ link }) => {
+const LinkElement = ({ link, next }) => {
   const location = useContext(LocationContext);
+  const handleClick = () => {
+    location.setUrl(link.href);
+    next();
+  };
+
   return (
     <button
       className={`${location.locationUrl === link.href ? 'active' : ''}`}
-      onClick={() => location.setUrl(link.href)}
+      onClick={handleClick}
     >
       {link.title ? (
         <>

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -28,7 +28,7 @@ const LinkElement = ({ link }) => {
       className={`${location.locationUrl === link.href ? 'active' : ''}`}
       onClick={() => location.setUrl(link.href)}
     >
-      <span className="link__title">{link.text}</span>
+      <span className="link__title">{link.title ? link.title : link.text}</span>
     </button>
   );
 };

--- a/src/components/schema-ui/schema-menu-attribute.js
+++ b/src/components/schema-ui/schema-menu-attribute.js
@@ -5,19 +5,22 @@ const SchemaMenuAttribute = ({ attribute }) => {
 
   return (
     <span className="menu__attribute">
-      <span className="link__title link__title--readable" onClick={() => setShowValue(!showValue)}>
+      <span
+        className="link__title link__title--readable"
+        onClick={() => setShowValue(!showValue)}
+      >
         {attribute.name}
       </span>
       {attribute.value && (
-        <ul className={`menu__attribute_properties ${showValue ? 'is-active' : 'is-inactive'}`}>
-          {Object.keys(attribute.value).map((attr, index) => (
-            <li>
-              <span
-                key={`${attr}-${index}`}
-                className="link__text link__text--machine"
-              >
-                {attr}:{' '}
-                <strong>{JSON.stringify(attribute.value[attr])}</strong>
+        <ul
+          className={`menu__attribute_properties ${
+            showValue ? 'is-active' : 'is-inactive'
+          }`}
+        >
+          {Object.entries(attribute.value).map(([key, value], index) => (
+            <li key={`${attribute.name}-${key}-${index}`}>
+              <span className="link__text link__text--machine">
+                {key}: <strong>{JSON.stringify(value)}</strong>
               </span>
             </li>
           ))}

--- a/src/components/schema-ui/schema-menu-attribute.js
+++ b/src/components/schema-ui/schema-menu-attribute.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+
+const SchemaMenuAttribute = ({ attribute }) => {
+  const [showValue, setShowValue] = useState(false);
+
+  return (
+    <span className="menu__attribute">
+      <span className="link__title link__title--readable" onClick={() => setShowValue(!showValue)}>
+        {attribute.name}
+      </span>
+      {attribute.value && (
+        <ul className={`menu__attribute_properties ${showValue ? 'is-active' : 'is-inactive'}`}>
+          {Object.keys(attribute.value).map((attr, index) => (
+            <li>
+              <span
+                key={`${attr}-${index}`}
+                className="link__text link__text--machine"
+              >
+                {attr}:{' '}
+                <strong>{JSON.stringify(attribute.value[attr])}</strong>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </span>
+  );
+};
+
+export default SchemaMenuAttribute;

--- a/src/components/schema-ui/schema-menu.js
+++ b/src/components/schema-ui/schema-menu.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import useSchema from '../../hooks/use-schema';
+import SchemaMenuAttribute from './schema-menu-attribute';
 
 const SchemaMenu = ({ forPath, load, back, next }) => {
   const schema = useSchema(forPath);
@@ -22,22 +23,7 @@ const SchemaMenu = ({ forPath, load, back, next }) => {
       <ul className="menu__nav">
         {attributes.map((attribute, index) => (
           <li key={index}>
-            <span className="menu__attribute">
-              <span className="link__title link__title--readable">
-                {attribute.name}
-              </span>
-              {attribute.value &&
-                <div>
-                  <ul className="menu__attribute_properties">
-                  {Object.keys(attribute.value).map((attr, index) => (
-                    <li><span key={`${attr}-${index}`} className="link__text link__text--machine">
-                      {attr}: <strong>{JSON.stringify(attribute.value[attr])}</strong>
-                    </span>
-                    </li>
-                  ))}
-                  </ul>
-                </div>}
-            </span>
+            <SchemaMenuAttribute attribute={attribute} />
           </li>
         ))}
         {relationships.map((relationship, index) => (

--- a/src/components/schema-ui/schema-menu.js
+++ b/src/components/schema-ui/schema-menu.js
@@ -20,13 +20,13 @@ const SchemaMenu = ({ forPath, load, back, next }) => {
         {attributes.map((attribute, index) => (
           <li key={index}>{attribute.name}</li>
         ))}
-      </ul>
-      <hr />
-      <ul className="menu__nav">
         {relationships.map((relationship, index) => (
           <li key={index}>
-            <span>{relationship.name}</span>
-            <button onClick={() => loadNext(relationship.name)}>load</button>
+            <button className="link--next" onClick={() => loadNext(relationship.name)}>
+              <span className="link__title link__title--readable">
+                {relationship.name}
+              </span>
+              </button>
           </li>
         ))}
       </ul>

--- a/src/components/schema-ui/schema-menu.js
+++ b/src/components/schema-ui/schema-menu.js
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import useSchema from '../../hooks/use-schema';
+
+const SchemaMenu = ({ forPath, load, back, next }) => {
+  const schema = useSchema(forPath);
+  const { type = '', attributes = [], relationships = [] } = schema || {};
+
+  const loadNext = name => {
+    load([...forPath, name]);
+    next();
+  };
+
+  return (
+    <div className="menu__container">
+      <div className="menu__location">
+        {type} <button onClick={back}>Back</button>
+      </div>
+      <ul className="menu__nav">
+        {attributes.map((attribute, index) => (
+          <li key={index}>{attribute.name}</li>
+        ))}
+      </ul>
+      <hr />
+      <ul className="menu__nav">
+        {relationships.map((relationship, index) => (
+          <li key={index}>
+            <span>{relationship.name}</span>
+            <button onClick={() => loadNext(relationship.name)}>load</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default SchemaMenu;

--- a/src/components/schema-ui/schema-menu.js
+++ b/src/components/schema-ui/schema-menu.js
@@ -14,11 +14,31 @@ const SchemaMenu = ({ forPath, load, back, next }) => {
   return (
     <div className="menu__container">
       <div className="menu__location">
-        {type} <button onClick={back}>Back</button>
+        <button className="link--prev" onClick={back}>
+          Back
+        </button>
+        <span className="menu__location_title">{type}</span>
       </div>
       <ul className="menu__nav">
         {attributes.map((attribute, index) => (
-          <li key={index}>{attribute.name}</li>
+          <li key={index}>
+            <span className="menu__attribute">
+              <span className="link__title link__title--readable">
+                {attribute.name}
+              </span>
+              {attribute.value &&
+                <div>
+                  <ul className="menu__attribute_properties">
+                  {Object.keys(attribute.value).map((attr, index) => (
+                    <li><span key={`${attr}-${index}`} className="link__text link__text--machine">
+                      {attr}: <strong>{JSON.stringify(attribute.value[attr])}</strong>
+                    </span>
+                    </li>
+                  ))}
+                  </ul>
+                </div>}
+            </span>
+          </li>
         ))}
         {relationships.map((relationship, index) => (
           <li key={index}>

--- a/src/components/schema-ui/schema-menu.js
+++ b/src/components/schema-ui/schema-menu.js
@@ -22,11 +22,14 @@ const SchemaMenu = ({ forPath, load, back, next }) => {
         ))}
         {relationships.map((relationship, index) => (
           <li key={index}>
-            <button className="link--next" onClick={() => loadNext(relationship.name)}>
+            <button
+              className="link--next"
+              onClick={() => loadNext(relationship.name)}
+            >
               <span className="link__title link__title--readable">
                 {relationship.name}
               </span>
-              </button>
+            </button>
           </li>
         ))}
       </ul>

--- a/src/components/schema-ui/schema-menu.js
+++ b/src/components/schema-ui/schema-menu.js
@@ -22,12 +22,12 @@ const SchemaMenu = ({ forPath, load, back, next }) => {
       </div>
       <ul className="menu__nav">
         {attributes.map((attribute, index) => (
-          <li key={index}>
+          <li key={`attribute-${index}`}>
             <SchemaMenuAttribute attribute={attribute} />
           </li>
         ))}
         {relationships.map((relationship, index) => (
-          <li key={index}>
+          <li key={`relationship-${index}`}>
             <button
               className="link--next"
               onClick={() => loadNext(relationship.name)}

--- a/src/css/base/_variables.scss
+++ b/src/css/base/_variables.scss
@@ -39,6 +39,7 @@
   --color-neutral: #E5E5E5;
 
   --width-aside: 320px;
+  --nav-offset: 0;
 
   /**
    * Spaces.

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -98,51 +98,86 @@ nav {
   overflow: scroll;
   width: var(--width-aside);
 
-  li {
+  & > li {
     margin: 0;
     padding: 0;
     border-top: 1px solid var(--color-lightgray);
   }
-  button {
-    width: 100%;
-    &:focus, &:hover {
-      background-color: var(--color-bgblue-hover);
-      outline: none;
-    }
-
-    &.active {
-      background-color: var(--color-bgblue-active);
-    }
-  }
 }
 
-.menu__location,
-.menu__nav button {
-  padding: var(--space-s);
-  padding-left: var(--space-xl);
-  border: none;
-  text-align: left;
+.menu__location_title,
+.menu__attribute {
+  padding: var(--space-s) var(--space-xl);
+  display: block;
 }
 
 .menu__location {
   font-weight: 700;
+  box-shadow: 10px 0px 20px rgba(0, 0, 0, 0.25);
+  background: var(--color-white);
 }
 
+.menu__attribute {
+  display: block;
+}
 
-.link--next {
-  display:flex;
-  justify-content: space-between;
-  align-items: center;
+.menu__attribute,
+.menu__container button {
+  font-size: .8rem;
+  line-height: 1.2em;
 
-  &:after {
-    content: '';
-    width: 24px;
-    height: 24px;
-    background: url(../img/dropdown.svg) no-repeat;
-    transform: rotate(-90deg);
+  &:focus, &:hover {
+    background-color: var(--color-bgblue-hover);
+    outline: none;
+  }
+
+  &.active {
+    background-color: var(--color-bgblue-active);
   }
 }
 
+.menu__container button {
+  border: none;
+  text-align: left;
+  width: 100%;
+}
+
+.link--prev,
+.link--next {
+  padding-top: var(--space-s);
+  padding-bottom: var(--space-s);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.link--prev:before,
+.link--next:after {
+  content: '';
+  width: 24px;
+  height: 24px;
+  top: var(--space-s);
+  background: url(../img/dropdown.svg) no-repeat;
+}
+
+.link--prev {
+  padding-right:  var(--space-xl);
+  padding-left: var(--space-s);
+
+  &:before {
+    left: var(--space-s);
+    transform: rotate(90deg);
+  }
+}
+.link--next {
+  padding-right: var(--space-s);
+  padding-left:  var(--space-xl);
+
+  &:after {
+    right: var(--space-s);
+    transform: rotate(-90deg);
+  }
+}
 
 ul {
   list-style: none;

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -119,6 +119,10 @@ nav {
 
 .menu__attribute {
   display: block;
+
+  .link__title {
+    cursor: pointer;
+  }
 }
 
 .menu__attribute,
@@ -133,6 +137,22 @@ nav {
 
   &.active {
     background-color: var(--color-bgblue-active);
+  }
+}
+
+.menu__attribute_properties {
+  max-height: 0;
+  transition: .25s all ease-in-out;
+  overflow: hidden;
+
+  &.is-active {
+    max-height: 500px;
+  }
+
+  > li:first-child {
+    border-top: 1px solid var(--color-davysgrey);
+    margin-top: .2rem;
+    padding-top: .2rem;
   }
 }
 

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -118,7 +118,8 @@ nav {
 
 .menu__location,
 .menu__nav button {
-  padding: var(--space-s) var(--space-xl);
+  padding: var(--space-s);
+  padding-left: var(--space-xl);
   border: none;
   text-align: left;
 }
@@ -127,6 +128,20 @@ nav {
   font-weight: 700;
 }
 
+
+.link--next {
+  display:flex;
+  justify-content: space-between;
+  align-items: center;
+
+  &:after {
+    content: '';
+    width: 24px;
+    height: 24px;
+    background: url(../img/dropdown.svg) no-repeat;
+    transform: rotate(-90deg);
+  }
+}
 
 
 ul {
@@ -188,7 +203,6 @@ button {
   padding: .5rem;
   background: #F3F4F9;
 }
-
 
 .tab {
   display: none;

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -81,14 +81,23 @@ main {
 
 nav {
   background: var(--color-neutral);
-  display: flex;
-  flex-direction: column;
   overflow: hidden;
+  display: flex;
 }
 
-.resourceLinks__nav {
+.menu__container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(calc(-1 * var(--nav-offset) * var(--width-aside)));
+  transition: .25s transform ease-in-out;
+}
+
+.menu__nav {
   flex: 1;
   overflow: scroll;
+  width: var(--width-aside);
+
   li {
     margin: 0;
     padding: 0;
@@ -107,14 +116,14 @@ nav {
   }
 }
 
-.resourceLinks__location,
-.resourceLinks__nav button {
+.menu__location,
+.menu__nav button {
   padding: var(--space-s) var(--space-xl);
   border: none;
   text-align: left;
 }
 
-.resourceLinks__location {
+.menu__location {
   font-weight: 700;
 }
 

--- a/src/img/dropdown.svg
+++ b/src/img/dropdown.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 7.5L12 16.5L21 7.5" stroke="#545560" stroke-width="2"/>
+</svg>

--- a/src/img/dropdown.svg
+++ b/src/img/dropdown.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M3 7.5L12 16.5L21 7.5" stroke="#545560" stroke-width="2"/>
+<path d="M3 7.5L12 16.5L21 7.5" stroke="#222330" stroke-width="2"/>
 </svg>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,13 @@ module.exports = {
           'sass-loader'
         ],
       },
+      {
+        test: /\.svg/,
+        use: {
+          loader: 'svg-url-loader',
+          options: {}
+        }
+      }
     ],
   },
   plugins: [


### PR DESCRIPTION
This is a first attempt at making the "menu bar" more of a schema explorer. I left the existing schema ui in place since I haven't fully replaced it yet.

The concept is that as a forPath is added it creates a new menu, so that the length of the forPath corresponds to the position in the menu list- that is, `[]` is the 0 position, `['uid']` for example would be the next position. When you go "back" and select another option that depth only is replaced, but if you go farther back it replaces the menus "after" that index.

I also added a way to view the "values" of an attribute since this is something that exists in the GraphiQl explorer.