### PR TITLE
Attribute card

### DIFF
--- a/src/components/schema-ui/schema-menu-attribute.js
+++ b/src/components/schema-ui/schema-menu-attribute.js
@@ -1,32 +1,52 @@
-import React, { useState } from 'react';
+import React from 'react';
+
+const SchemaMenuAttributeName = ({ name }) => (
+  <div className="menu__attribute">
+    <span className="link__title link__title--readable">{name}</span>
+  </div>
+);
+
+const SchemaMenuAttributeValue = ({ name, value }) => {
+  const { type, title, description, properties, ...values } = value;
+
+  return type === 'object' ? (
+    <div className="menu__attribute menu__attribute_object">
+      <span className="link__title link__title--readable">{title}</span>
+      <span className="link__text link__text--machine">{name}</span>
+      <ul className="menu__attribute_properties">
+        {Object.entries(properties).map(([key, value], index) => (
+          <li key={`${name}-${key}-${index}`}>
+            <SchemaMenuAttribute attribute={{ name: key,value }} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  ) : (
+    <div className="menu__attribute">
+      <span className="link__title link__title--readable">{title}</span>
+      <span className="link__text link__text--machine">
+        {name}:<span className="link__text--type">{type}</span>
+      </span>
+      <ul className="menu__attribute_properties">
+        {Object.entries(values).map(([key, value], index) => (
+          <li key={`${name}-${key}-${index}`}>
+            <span className="link__text link__text--machine">
+              {key}: <strong>{typeof value === 'object' ? JSON.stringify(value) : value}</strong>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
 
 const SchemaMenuAttribute = ({ attribute }) => {
-  const [showValue, setShowValue] = useState(false);
+  const { name, value } = attribute;
 
-  return (
-    <span className="menu__attribute">
-      <span
-        className="link__title link__title--readable"
-        onClick={() => setShowValue(!showValue)}
-      >
-        {attribute.name}
-      </span>
-      {attribute.value && (
-        <ul
-          className={`menu__attribute_properties ${
-            showValue ? 'is-active' : 'is-inactive'
-          }`}
-        >
-          {Object.entries(attribute.value).map(([key, value], index) => (
-            <li key={`${attribute.name}-${key}-${index}`}>
-              <span className="link__text link__text--machine">
-                {key}: <strong>{JSON.stringify(value)}</strong>
-              </span>
-            </li>
-          ))}
-        </ul>
-      )}
-    </span>
+  return value ? (
+    <SchemaMenuAttributeValue name={name} value={value} />
+  ) : (
+    <SchemaMenuAttributeName name={name} />
   );
 };
 

--- a/src/components/schema-ui/schema-menu-attribute.js
+++ b/src/components/schema-ui/schema-menu-attribute.js
@@ -9,32 +9,29 @@ const SchemaMenuAttributeName = ({ name }) => (
 const SchemaMenuAttributeValue = ({ name, value }) => {
   const { type, title, description, properties, ...values } = value;
 
-  return type === 'object' ? (
-    <div className="menu__attribute menu__attribute_object">
-      <span className="link__title link__title--readable">{title}</span>
-      <span className="link__text link__text--machine">{name}</span>
+  return (
+    <div className={`menu__attribute menu__attribute--${type}`}>
+      <div className="menu__attribute_header">
+        <span className="link__title link__title--readable">{title}</span>
+        <span className="link__text link__text--machine">{name}</span>
+        {type !== 'object' && <span className="link__text_type link__text--machine">{type}</span>}
+        {description && <p className="link__text_description">{description}</p>}
+      </div>
       <ul className="menu__attribute_properties">
-        {Object.entries(properties).map(([key, value], index) => (
-          <li key={`${name}-${key}-${index}`}>
-            <SchemaMenuAttribute attribute={{ name: key,value }} />
-          </li>
-        ))}
-      </ul>
-    </div>
-  ) : (
-    <div className="menu__attribute">
-      <span className="link__title link__title--readable">{title}</span>
-      <span className="link__text link__text--machine">
-        {name}:<span className="link__text--type">{type}</span>
-      </span>
-      <ul className="menu__attribute_properties">
-        {Object.entries(values).map(([key, value], index) => (
-          <li key={`${name}-${key}-${index}`}>
-            <span className="link__text link__text--machine">
-              {key}: <strong>{typeof value === 'object' ? JSON.stringify(value) : value}</strong>
-            </span>
-          </li>
-        ))}
+        {properties
+          ? Object.entries(properties).map(([key, value], index) => (
+              <li key={`${name}-${key}-${index}`}>
+                <SchemaMenuAttribute attribute={{ name: key, value }} />
+              </li>
+            ))
+          : Object.entries(values).map(([key, value], index) => (
+              <li key={`${name}-${key}-${index}`}>
+                <span className="link__text link__text_label">{key}</span>
+                <span className="link__text link__text_value">
+                  : {JSON.stringify(value)}
+                </span>
+              </li>
+            ))}
       </ul>
     </div>
   );

--- a/src/components/schema-ui/schema-menu.js
+++ b/src/components/schema-ui/schema-menu.js
@@ -22,7 +22,7 @@ const SchemaMenu = ({ forPath, load, back, next }) => {
       </div>
       <ul className="menu__nav">
         {attributes.map((attribute, index) => (
-          <li key={`attribute-${index}`}>
+          <li key={`attribute-${index}`} className="menu__nav_item">
             <SchemaMenuAttribute attribute={attribute} />
           </li>
         ))}

--- a/src/css/base/_variables.scss
+++ b/src/css/base/_variables.scss
@@ -41,6 +41,8 @@
   --width-aside: 320px;
   --nav-offset: 0;
 
+  --radius-s: 5px;
+
   /**
    * Spaces.
    */

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -120,12 +120,8 @@ nav {
 .menu__attribute {
   display: block;
 
-  .link__title {
-    cursor: pointer;
-  }
 }
 
-.menu__attribute,
 .menu__container button {
   font-size: .8rem;
   line-height: 1.2em;
@@ -141,18 +137,9 @@ nav {
 }
 
 .menu__attribute_properties {
-  max-height: 0;
-  transition: .25s all ease-in-out;
-  overflow: hidden;
 
-  &.is-active {
-    max-height: 500px;
-  }
-
-  > li:first-child {
-    border-top: 1px solid var(--color-davysgrey);
-    margin-top: .2rem;
-    padding-top: .2rem;
+  .menu__attribute {
+    padding: var(--space-s);
   }
 }
 

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -101,25 +101,55 @@ nav {
   & > li {
     margin: 0;
     padding: 0;
-    border-top: 1px solid var(--color-lightgray);
   }
 }
 
-.menu__location_title,
-.menu__attribute {
-  padding: var(--space-s) var(--space-xl);
-  display: block;
+.menu__nav_item {
+
+  & > .menu__attribute {
+    & > .menu__attribute_header,
+    & > .menu__attribute_properties {
+      padding: var(--space-s);
+      background: var(--color-white);
+    }
+  }
+
+  font-size: .8rem;
 }
 
 .menu__location {
   font-weight: 700;
   box-shadow: 10px 0px 20px rgba(0, 0, 0, 0.25);
+  z-index: 2;
   background: var(--color-white);
 }
 
-.menu__attribute {
+.menu__location_title {
+  padding: var(--space-s) var(--space-l);
   display: block;
+}
 
+
+.menu__attribute {
+  margin: 4px var(--space-s);
+}
+
+
+.menu__attribute_header {
+  border-top-right-radius: var(--radius-s);
+  border-top-left-radius: var(--radius-s);
+}
+
+.menu__attribute_properties {
+  border-bottom-right-radius: var(--radius-s);
+  border-bottom-left-radius: var(--radius-s);
+}
+
+.menu__attribute--object {
+
+  .menu__attribute_header {
+    margin-bottom: 2px;
+  }
 }
 
 .menu__container button {
@@ -139,7 +169,7 @@ nav {
 .menu__attribute_properties {
 
   .menu__attribute {
-    padding: var(--space-s);
+    padding: 0;
   }
 }
 
@@ -168,7 +198,7 @@ nav {
 }
 
 .link--prev {
-  padding-right:  var(--space-xl);
+  padding-right:  var(--space-l);
   padding-left: var(--space-s);
 
   &:before {
@@ -178,7 +208,7 @@ nav {
 }
 .link--next {
   padding-right: var(--space-s);
-  padding-left:  var(--space-xl);
+  padding-left:  var(--space-l);
 
   &:after {
     right: var(--space-s);
@@ -228,8 +258,22 @@ li {
   font-weight: 700;
 }
 
-.link__title--machine {
+.link__text--machine {
   font-family: $ff-mono;
+}
+
+
+.link__text_type {
+  color: var(--color-grayblue);
+  &::before {
+    content: ':';
+  }
+}
+
+.link__text_description {
+  margin: 0 0 .5rem 0;
+  font-style: italic;
+  color: var(--color-oldsilver);
 }
 
 button {


### PR DESCRIPTION
Displaying the attribute properties better, this should set us up for using that main attribute component where it is most effective, such as the `body.value` vs the value. Without schema it falls back to just displaying the field machine name.

