### PR TITLE
Panels

### DIFF
--- a/src/components/param-ui/attribute-loader.js
+++ b/src/components/param-ui/attribute-loader.js
@@ -1,0 +1,91 @@
+import React, { useState, useContext } from 'react';
+
+import useSchema from '../../hooks/use-schema';
+import useSchemaLoader from '../../hooks/use-schema-loader';
+import { checkIncludesPath, hasSetEntry, toggleSetEntry } from '../../utils';
+import { LocationContext } from '../../contexts/location';
+
+const Attribute = ({ attribute, type, includeEnabled }) => {
+  const { fields, toggleField } = useContext(LocationContext);
+  return (
+    <div className="attribute">
+      <input
+        type="checkbox"
+        checked={
+          fields.hasOwnProperty(type) &&
+          hasSetEntry(fields[type], attribute.name)
+        }
+        disabled={!includeEnabled}
+        onChange={() => toggleField(type, attribute.name)}
+      />
+      {attribute.name}
+    </div>
+  );
+};
+const AttributeLoaderList = ({ path, load }) => {
+  const { forPath } = path;
+  const { include } = useContext(LocationContext);
+  const includesEnabled = checkIncludesPath(include, forPath);
+  const schema = useSchema(forPath);
+
+  const handleChange = e => {
+    load({ forPath: [...forPath, e.target.value] });
+  };
+
+  if (schema) {
+    const { attributes, relationships } = schema;
+
+    return (
+      <div>
+        {attributes.map(attribute => (
+          <Attribute
+            key={`${schema.type}-${attribute.name}`}
+            attribute={attribute}
+            type={schema.type}
+            includeEnabled={includesEnabled}
+          />
+        ))}
+        <select onChange={handleChange}>
+          <option value="">Select a relationship</option>
+          {relationships.map(relationship => (
+            <option
+              key={[...forPath, relationship.name].join('-')}
+              value={relationship.name}
+            >
+              {relationship.name}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+
+  return <></>;
+};
+
+const AttributeLoader = () => {
+  const [values, setValues] = useState(new Set([]));
+  const { paths, load } = useSchemaLoader([]);
+
+  const addAttribute = attribute => {
+    const current = new Set([...values]);
+    setValues(toggleSetEntry(current, attribute));
+  };
+
+  return (
+    <form className="param_ui__fieldset_form">
+      {paths.map((path, index) => (
+        <AttributeLoaderList
+          key={[...path.forPath, index].join('-')}
+          index={index}
+          path={path}
+          load={load}
+          values={values}
+          addAttribute={addAttribute}
+        />
+      ))}
+    </form>
+  );
+};
+
+export default AttributeLoader;

--- a/src/components/param-ui/fieldset-ui.js
+++ b/src/components/param-ui/fieldset-ui.js
@@ -1,34 +1,50 @@
-import React, { useContext } from 'react';
+import React, { useState, useContext } from 'react';
 
 import { LocationContext } from '../../contexts/location';
+import AttributeLoader from './attribute-loader';
 
 const FieldsetUI = () => {
   const { fields, toggleField, clearFieldSet } = useContext(LocationContext);
+  const [editMode, setEditMode] = useState(false);
 
   return (
-    <ul className="scrollable scrollable_y">
-      {Object.keys(fields).map((type, index) => (
-        <li key={`${type}-${index}`}>
+    <div className="param_ui param_ui__fieldset">
+      <span className="param_ui__title">Fieldset</span>
+      {editMode ? (
+        <div className="param_ui__content param_ui__content--edit
+        param_ui__fieldset--edit">
+          <AttributeLoader />
+          <button onClick={() => setEditMode(false)}>Done</button>
+        </div>
+      ) : (
+        <div className="param_ui__content param_ui__content--view param_ui__fieldset--view">
           <ul>
-            {Array.from(fields[type]).map(setEntry => (
-              <li key={`${type}-${setEntry}`}>
-                <button onClick={() => toggleField(type, setEntry)}>
-                  <strong>Clear </strong>
-                  <code>
-                    {type}.{setEntry}
-                  </code>
+            {Object.keys(fields).map((type, index) => (
+              <li key={`${type}-${index}`}>
+                <ul>
+                  {Array.from(fields[type]).map(setEntry => (
+                    <li key={`${type}-${setEntry}`}>
+                      <button onClick={() => toggleField(type, setEntry)}>
+                        <strong>Clear </strong>
+                        <code>
+                          {type}.{setEntry}
+                        </code>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+                <button onClick={() => clearFieldSet(type)}>
+                  <strong>Clear all </strong>
+                  <code>{type}</code>
+                  <strong> fields</strong>
                 </button>
               </li>
             ))}
           </ul>
-          <button onClick={() => clearFieldSet(type)}>
-            <strong>Clear all </strong>
-            <code>{type}</code>
-            <strong> fields</strong>
-          </button>
-        </li>
-      ))}
-    </ul>
+          <button onClick={() => setEditMode(true)}>Add</button>
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/components/param-ui/include-loader.js
+++ b/src/components/param-ui/include-loader.js
@@ -1,63 +1,76 @@
 import React, { useState, useContext } from 'react';
 
 import useSchema from '../../hooks/use-schema';
-import { LocationContext } from '../../contexts/location';
 import { isEmpty } from '../../utils';
 
 const IncludeLoaderOption = ({ name }) => <option value={name}>{name}</option>;
 
-const IncludeLoaderList = ({ forPath }) => {
-  const { include, toggleInclude } = useContext(LocationContext);
-  const [selected, setSelected] = useState('');
-  const includePathString = forPath.join('.');
+const IncludeLoaderList = ({ forPath, onChange }) => {
   const schema = useSchema(forPath);
+  const [selected, setSelected] = useState('');
 
   if (!schema) {
     return <div />;
   }
 
+  const { relationships } = schema;
+
   const handleChange = e => {
+    if (e.target.value !== '') {
+      onChange([...forPath, e.target.value], forPath.length);
+    }
+
     setSelected(e.target.value);
+  };
+
+  return !isEmpty(relationships) ? (
+    <select value={selected} onChange={handleChange}>
+      <option value="">- Select a relationship -</option>
+      {relationships
+        .map(relationship => relationship.name)
+        .map((name, index) => (
+          <IncludeLoaderOption key={index} name={name} />
+        ))}
+    </select>
+  ) : (
+    <></>
+  );
+};
+
+const IncludeLoader = ({ onSubmit }) => {
+  const initialPath = [];
+  const [paths, setPaths] = useState([initialPath]);
+
+  const handleChange = (path, index) => {
+    const current = paths.slice(0, index + 1);
+    current.push(path);
+    setPaths(current);
   };
 
   const handleSubmit = e => {
     e.preventDefault();
 
-    if (selected !== '') {
-      toggleInclude(selected);
-      setSelected('');
+    if (paths.length > 1) {
+      onSubmit(paths.slice(-1).pop());
     }
   };
 
-
-  const { relationships } = schema;
-
-  return !isEmpty(relationships) ? (
+  return (
     <form onSubmit={handleSubmit}>
-      <span>{includePathString}</span>
-      <select value={selected} onChange={handleChange}>
-        <option value="">- Select a relationship -</option>
-        {relationships
-          .map(relationship => [...forPath, relationship.name].join('.'))
-          .filter(name => include.indexOf(name) === -1)
-          .map((name, index) => (
-            <IncludeLoaderOption key={index} name={name} />
-          ))}
-      </select>
-      <button type="submit">Add</button>
+      {paths.map((forPath, index) => {
+        return (
+          <IncludeLoaderList
+            key={index}
+            forPath={forPath}
+            onChange={handleChange}
+          />
+        );
+      })}
+      <button onClick={handleSubmit} type="submit">
+        Done
+      </button>
     </form>
-  ) : (
-    <div />
   );
-};
-
-const IncludeLoader = () => {
-  const { include } = useContext(LocationContext);
-  const paths = [[], ...include.map(path => path.split('.'))];
-
-  return paths.map((forPath, index) => (
-    <IncludeLoaderList key={index} forPath={forPath} />
-  ));
 };
 
 export default IncludeLoader;

--- a/src/components/param-ui/include-loader.js
+++ b/src/components/param-ui/include-loader.js
@@ -1,19 +1,45 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 import useSchema from '../../hooks/use-schema';
 
-const IncludeLoader = forPath => {
-
+const IncludeLoaderList = ({forPath, load}) => {
   const schema = useSchema(forPath);
 
   if (schema) {
     const { relationships } = schema;
-    return (
-      relationships.map(relationship => <div>{relationship.name}</div>)
-    );
+    return relationships.map((relationship, index) => (
+      <div key={index}
+        onClick={() => load({
+            title: relationship.name,
+            forPath: [...forPath, relationship.name],
+          })
+        }
+      >
+        {relationship.name}
+      </div>
+    ));
   }
-  return (<div></div>)
+  return <div />;
+};
 
+const IncludeLoader = () => {
+  const [loadedInclude, setLoadedInclude] = useState([]);
+  const schema = useSchema([]);
+
+  const loadNext = next => {
+    const loaded = loadedInclude.slice(0, next.forPath.length);
+    setLoadedInclude([...loaded, next]);
+  };
+
+  useEffect(() => {
+    if (schema) {
+      loadNext({title: schema.type, forPath: []});
+    }
+  }, [schema]);
+
+  return loadedInclude.map((include, index) => (
+    <IncludeLoaderList key={index} forPath={include.forPath} load={loadNext} />
+  ));
 };
 
 export default IncludeLoader;

--- a/src/components/param-ui/include-loader.js
+++ b/src/components/param-ui/include-loader.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import useSchema from '../../hooks/use-schema';
+
+const IncludeLoader = forPath => {
+
+  const schema = useSchema(forPath);
+
+  if (schema) {
+    const { relationships } = schema;
+    return (
+      relationships.map(relationship => <div>{relationship.name}</div>)
+    );
+  }
+  return (<div></div>)
+
+};
+
+export default IncludeLoader;

--- a/src/components/param-ui/include-ui.js
+++ b/src/components/param-ui/include-ui.js
@@ -19,14 +19,14 @@ const IncludeUI = () => {
   };
 
   return schema ? (
-    <div className="param_ui__include">
+    <div className="param_ui param_ui__include">
       <span className="param_ui__title">Includes</span>
       {editMode ? (
-      <div className="param_ui__include--edit">
+      <div className="param_ui__content param_ui__content--edit param_ui__include--edit">
         <IncludeLoader onSubmit={addInclude} />
       </div>
       ) : (
-      <div className="param_ui__include--view">
+      <div className="param_ui__content param_ui__content--view param_ui__include--view">
         {include.map((path, index) => (
           <button key={index} onClick={() => toggleInclude(path)}>
             <code>{path}</code>

--- a/src/components/param-ui/include-ui.js
+++ b/src/components/param-ui/include-ui.js
@@ -1,11 +1,15 @@
 import React, { useContext } from 'react';
 
 import { LocationContext } from '../../contexts/location';
+import IncludeLoader from './include-loader';
 
 const IncludeUI = () => {
   const { include, toggleInclude } = useContext(LocationContext);
+
   return (
-    <ul className="scrollable scrollable_y">
+    <div className="param_ui__include">
+    <IncludeLoader forPath={[]} />
+    <ul>
       {include.map((path, index) => (
         <li key={index}>
           <button onClick={() => toggleInclude(path)}>
@@ -15,6 +19,7 @@ const IncludeUI = () => {
         </li>
       ))}
     </ul>
+    </div>
   );
 };
 

--- a/src/components/param-ui/include-ui.js
+++ b/src/components/param-ui/include-ui.js
@@ -9,13 +9,21 @@ const IncludeUI = () => {
   const { include, toggleInclude } = useContext(LocationContext);
   const [editMode, setEditMode] = useState(false);
 
+  // At this level path should be a real forPath like ['uid', 'roles']
+  const addInclude = path => {
+    const includePathString = path.join('.');
+    if (include.indexOf(includePathString) === -1) {
+      toggleInclude(includePathString);
+    }
+    setEditMode(false);
+  };
+
   return schema ? (
     <div className="param_ui__include">
       <span className="param_ui__title">Includes</span>
       {editMode ? (
       <div className="param_ui__include--edit">
-        <IncludeLoader />
-        <button onClick={() => setEditMode(false)}>Done</button>
+        <IncludeLoader onSubmit={addInclude} />
       </div>
       ) : (
       <div className="param_ui__include--view">

--- a/src/components/param-ui/include-ui.js
+++ b/src/components/param-ui/include-ui.js
@@ -1,25 +1,35 @@
-import React, { useContext } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 
 import { LocationContext } from '../../contexts/location';
 import IncludeLoader from './include-loader';
+import useSchema from '../../hooks/use-schema';
 
 const IncludeUI = () => {
+  const schema = useSchema([]);
   const { include, toggleInclude } = useContext(LocationContext);
+  const [editMode, setEditMode] = useState(false);
 
-  return (
+  return schema ? (
     <div className="param_ui__include">
-    <IncludeLoader forPath={[]} />
-    <ul>
-      {include.map((path, index) => (
-        <li key={index}>
-          <button onClick={() => toggleInclude(path)}>
-            <strong>Clear </strong>
+      <span className="param_ui__title">Includes</span>
+      {editMode ? (
+      <div className="param_ui__include--edit">
+        <IncludeLoader />
+        <button onClick={() => setEditMode(false)}>Done</button>
+      </div>
+      ) : (
+      <div className="param_ui__include--view">
+        {include.map((path, index) => (
+          <button key={index} onClick={() => toggleInclude(path)}>
             <code>{path}</code>
           </button>
-        </li>
-      ))}
-    </ul>
+        ))}
+        <button onClick={() => setEditMode(true)}>Add</button>
+      </div>
+      )}
     </div>
+  ) : (
+    <div />
   );
 };
 

--- a/src/components/resource.js
+++ b/src/components/resource.js
@@ -22,7 +22,6 @@ const Resource = () => {
           <FilterUI />
         </div>
         <div id="includes" className="controls_panel pane">
-          <h2>Includes</h2>
           <IncludeUI />
         </div>
         <div id="fields" className="controls_panel pane">

--- a/src/components/resource.js
+++ b/src/components/resource.js
@@ -25,7 +25,6 @@ const Resource = () => {
           <IncludeUI />
         </div>
         <div id="fields" className="controls_panel pane">
-          <h2>Fields</h2>
           <FieldsetUI />
         </div>
       </div>

--- a/src/css/_nav.scss
+++ b/src/css/_nav.scss
@@ -1,0 +1,130 @@
+
+nav {
+  background: var(--color-neutral);
+  overflow: hidden;
+  display: flex;
+}
+
+.menu__container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(calc(-1 * var(--nav-offset) * var(--width-aside)));
+  transition: .25s transform ease-in-out;
+}
+
+.menu__nav {
+  flex: 1;
+  overflow: scroll;
+  width: var(--width-aside);
+
+  & > li {
+    margin: var(--space-s) 0;
+    padding: 0;
+  }
+}
+
+.menu__nav_item {
+
+  & > .menu__attribute {
+    border-top-left-radius: var(--radius-s);
+    border-bottom-left-radius: var(--radius-s);
+
+    & > .menu__attribute_header,
+    & > .menu__attribute_properties {
+      padding: var(--space-s);
+    }
+    & > .menu__attribute_header {
+      background: var(--color-white);
+    }
+    & > .menu__attribute_properties {
+      background: var(--color-bgblue-light);
+    }
+  }
+
+  font-size: .8rem;
+}
+
+.menu__location {
+  font-weight: 700;
+  box-shadow: 10px 0px 20px rgba(0, 0, 0, 0.25);
+  z-index: 2;
+  background: var(--color-white);
+}
+
+.menu__location_title {
+  padding: var(--space-s);
+  display: block;
+}
+
+.menu__attribute_header {
+  border-top-left-radius: var(--radius-s);
+}
+
+.menu__attribute_properties {
+  border-bottom-left-radius: var(--radius-s);
+}
+
+.menu__container button {
+  font-size: .8rem;
+  line-height: 1.2em;
+
+  &:focus, &:hover {
+    background-color: var(--color-bgblue-hover);
+    outline: none;
+  }
+
+  &.active {
+    background-color: var(--color-bgblue-active);
+  }
+}
+
+.menu__attribute_properties {
+
+  .menu__attribute {
+    padding: 0;
+  }
+}
+
+.menu__container button {
+  border: none;
+  text-align: left;
+  width: 100%;
+}
+
+.link--prev,
+.link--next {
+  padding-top: var(--space-s);
+  padding-bottom: var(--space-s);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.link--prev:before,
+.link--next:after {
+  content: '';
+  width: 24px;
+  height: 24px;
+  top: var(--space-s);
+  background: url(../img/dropdown.svg) no-repeat;
+}
+
+.link--prev {
+  padding-right:  var(--space-s);
+  padding-left: var(--space-s);
+
+  &:before {
+    left: var(--space-s);
+    transform: rotate(90deg);
+  }
+}
+.link--next {
+  padding-right: var(--space-s);
+  padding-left:  var(--space-s);
+
+  &:after {
+    right: var(--space-s);
+    transform: rotate(-90deg);
+  }
+}

--- a/src/css/_param.scss
+++ b/src/css/_param.scss
@@ -1,5 +1,31 @@
+.param_ui {
+  display: flex;
+  flex-direction: column;
+
+}
+
+.param_ui__content--view {
+  flex: 1;
+  overflow-y: scroll;
+}
+
 .param_ui__include--view {
   button {
     margin-right: var(--space-s);
+  }
+}
+
+.param_ui__fieldset_form {
+  display: flex;
+
+  & > div {
+    overflow-y: scroll;
+  }
+}
+
+.param_ui__fieldset--view {
+
+  & > ul {
+    display: flex;
   }
 }

--- a/src/css/_param.scss
+++ b/src/css/_param.scss
@@ -1,0 +1,5 @@
+.param_ui__include--view {
+  button {
+    margin-right: var(--space-s);
+  }
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -34,16 +34,7 @@ h1 {
 }
 
 .controls_panel {
-  max-height: 30vh;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
 
-  & > ul {
-    border-top: 1px solid var(--color-lightgray);
-    overflow: scroll;
-    flex: 1;
-  }
 }
 
 .results-container {

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -1,5 +1,7 @@
 @import 'base/variables';
 @import 'header';
+@import 'nav';
+@import 'param';
 
 html, body {
   margin: 0;
@@ -29,9 +31,6 @@ h1 {
 
 .controls {
   margin-bottom: 2px;
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  grid-gap: 2px;
 }
 
 .controls_panel {
@@ -78,136 +77,6 @@ main {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-}
-
-nav {
-  background: var(--color-neutral);
-  overflow: hidden;
-  display: flex;
-}
-
-.menu__container {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  transform: translateX(calc(-1 * var(--nav-offset) * var(--width-aside)));
-  transition: .25s transform ease-in-out;
-}
-
-.menu__nav {
-  flex: 1;
-  overflow: scroll;
-  width: var(--width-aside);
-
-  & > li {
-    margin: var(--space-s) 0;
-    padding: 0;
-  }
-}
-
-.menu__nav_item {
-
-  & > .menu__attribute {
-    border-top-left-radius: var(--radius-s);
-    border-bottom-left-radius: var(--radius-s);
-
-    & > .menu__attribute_header,
-    & > .menu__attribute_properties {
-      padding: var(--space-s);
-    }
-    & > .menu__attribute_header {
-      background: var(--color-white);
-    }
-    & > .menu__attribute_properties {
-      background: var(--color-bgblue-light);
-    }
-  }
-
-  font-size: .8rem;
-}
-
-.menu__location {
-  font-weight: 700;
-  box-shadow: 10px 0px 20px rgba(0, 0, 0, 0.25);
-  z-index: 2;
-  background: var(--color-white);
-}
-
-.menu__location_title {
-  padding: var(--space-s);
-  display: block;
-}
-
-.menu__attribute_header {
-  border-top-left-radius: var(--radius-s);
-}
-
-.menu__attribute_properties {
-  border-bottom-left-radius: var(--radius-s);
-}
-
-.menu__container button {
-  font-size: .8rem;
-  line-height: 1.2em;
-
-  &:focus, &:hover {
-    background-color: var(--color-bgblue-hover);
-    outline: none;
-  }
-
-  &.active {
-    background-color: var(--color-bgblue-active);
-  }
-}
-
-.menu__attribute_properties {
-
-  .menu__attribute {
-    padding: 0;
-  }
-}
-
-.menu__container button {
-  border: none;
-  text-align: left;
-  width: 100%;
-}
-
-.link--prev,
-.link--next {
-  padding-top: var(--space-s);
-  padding-bottom: var(--space-s);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.link--prev:before,
-.link--next:after {
-  content: '';
-  width: 24px;
-  height: 24px;
-  top: var(--space-s);
-  background: url(../img/dropdown.svg) no-repeat;
-}
-
-.link--prev {
-  padding-right:  var(--space-s);
-  padding-left: var(--space-s);
-
-  &:before {
-    left: var(--space-s);
-    transform: rotate(90deg);
-  }
-}
-.link--next {
-  padding-right: var(--space-s);
-  padding-left:  var(--space-s);
-
-  &:after {
-    right: var(--space-s);
-    transform: rotate(-90deg);
-  }
 }
 
 ul {

--- a/src/hooks/use-schema-loader.js
+++ b/src/hooks/use-schema-loader.js
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+const useSchemaLoader = initialPath => {
+  const [paths, setPaths] = useState([{ forPath: initialPath }]);
+
+  const load = next => {
+    // forPath length corresponds to array depth.
+    const current = paths.slice(0, next.forPath.length);
+    setPaths([...current, next]);
+  };
+
+  return { paths, load };
+};
+
+export default useSchemaLoader;


### PR DESCRIPTION
The schema-ui for "include" is now editable directly from the panel. The panel now has a "view" mode for seeing and toggling (off) current relationships, and an "edit" mode where a "path" can be built by selecting relationships and child relationships, and then toggled into the path by clicking "done".
