### PR TITLE
Get rid of unnecessary unperformant calls to ResourceObject.copy

### DIFF
--- a/src/contexts/field-focus.js
+++ b/src/contexts/field-focus.js
@@ -79,7 +79,7 @@ const fieldFocusReducer = (state, action) => {
 };
 
 const chain = (state, ...actions) => {
-  return Object.assign(actions.reduce(fieldFocusReducer, state), {last: copyObject(state)});
+  return Object.assign(actions.reduce(fieldFocusReducer, state), {last: {...state}});
 };
 
 const FieldFocusContext = createContext(defaults);

--- a/src/lib/jsonapi-objects/document.js
+++ b/src/lib/jsonapi-objects/document.js
@@ -7,6 +7,8 @@ const schemaParser = new SchemaParser();
 export default class Document {
   constructor({ raw }) {
     this.raw = raw;
+    this.data = false;
+    this.included = false;
   }
 
   static parse(raw) {
@@ -14,18 +16,24 @@ export default class Document {
   }
 
   getData() {
-    return [this.raw.data]
-      .flat()
-      .map(ResourceObject.parse)
-      .map(obj => obj.withParentDocument(this));
+    if (this.data === false) {
+      this.data = [this.raw.data]
+        .flat()
+        .map(ResourceObject.parse)
+        .map(obj => obj.withParentDocument(this));
+    }
+    return this.data;
   }
 
   getIncluded() {
-    return this.hasIncluded()
-      ? this.raw.included
+    if (this.included === false) {
+      this.included = this.hasIncluded()
+        ? this.raw.included
           .map(ResourceObject.parse)
           .map(obj => obj.withParentDocument(this))
-      : [];
+        : [];
+    }
+    return this.included;
   }
 
   getRelated(fieldName) {


### PR DESCRIPTION
In #39 @zrpnr [pointed out](https://github.com/zrpnr/jsonapi_explorer/pull/39#discussion_r297261529) that focuses could be very sluggish and identified `findUniqueFieldNames` as the source of the slow work.

I dug into this a bit more and indeed, this function is getting called very often. However, that function is not necessarily slow, even if it is called many times. Within it, it calls `getRelated(fieldName)` on every resource and I believe this was the source of the slow performance.

Every call to `getRelated` was repeatedly instantiating new ResourceObjects and copying them, which meant that their JSON was getting repeatedly stringified and parsed many many times.

I went ahead and tried to eliminate any unnecessary work in that regard.