### PR TITLE
Add parse and compile for the `sort` and `page` parameter

### DIFF
--- a/src/lib/url/url.js
+++ b/src/lib/url/url.js
@@ -2,7 +2,7 @@ import { isEmpty } from '../../utils';
 
 const entrypointPath = process.env.ENTRYPOINT_PATH;
 
-const queryParams = ['include', 'filter', 'fields', 'sort'];
+const queryParams = ['include', 'filter', 'fields', 'sort', 'page'];
 
 export const parseListParameter = value => {
   return value ? value.split(',') : [];
@@ -127,6 +127,8 @@ export const compileQueryParameter = (baseName, query) => {
       return compileQueryParameterFamily(baseName, queryValue);
     case 'sort':
       return compileSortParameter(baseName, queryValue);
+    case 'page':
+      return compileQueryParameterFamily(baseName, queryValue);
 
     default:
       return `${baseName}=${compileListParameter(queryValue)}`;
@@ -147,6 +149,7 @@ export const parseJsonApiUrl = fromUrl => {
       include: parseListParameter(query.get('include')),
       fields: parseDictionaryParameter('fields', query.entries()),
       sort: parseSortParameter(query.get('sort')),
+      page: parseQueryParameterFamily('page', query.entries())
     },
     fragment: url.hash,
   };


### PR DESCRIPTION
I started implementing the sort panel in order to understand how the other panels were put together. While I threw away the work I had because it wasn't great, the parsing and compiling bits should still work fine.

This ensures that they'll appear in the location bar.

It does nothing to make the parameters editable in the UI.