### PR TITLE
Surface result count and react to an empty result

### DIFF
--- a/src/components/result-ui/display-raw.js
+++ b/src/components/result-ui/display-raw.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import CodeMirrorElem from './code-mirror';
 
@@ -24,7 +24,10 @@ const DisplayRaw = ({ title, name, responseDocument, children }) => {
           </ul>
           <div className={`tab flex-height ${activeTab === 0 ? 'tab__active' : ''}`}>
             <h2 className="tab__title">{title}</h2>
-            {children}
+            {(!Array.isArray(responseDocument.data) || responseDocument.data.length)
+              ? children
+              : <div />
+            }
           </div>
           <div className={`tab flex-height ${activeTab === 1 ? 'tab__active' : ''}`}>
             <h2 className="tab__title">Raw</h2>

--- a/src/components/result-ui/index.js
+++ b/src/components/result-ui/index.js
@@ -7,11 +7,15 @@ import Summary from "./summary";
 const ResultUI = () => {
   const { responseDocument } = useContext(LocationContext);
   const data = responseDocument ? responseDocument.getData() : [];
+  const isCollection = responseDocument && responseDocument.isCollectionDocument();
 
   return (
     <>
       <DisplayRaw
-        title="Results"
+        title={isCollection
+          ? data.length ? `Results (${data.length})` : 'No results'
+          : 'Result'
+        }
         name="results"
         responseDocument={responseDocument && responseDocument.raw}
       >

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -183,6 +183,11 @@ h2.tab__title {
   box-shadow: 0 20px 20px -20px rgba(0, 0, 0, .25);
 }
 
+.results__empty {
+  margin: 0;
+  padding: var(--space-l) var(--space-s);
+}
+
 .results__raw .CodeMirror {
   flex: 1;
   display: flex;


### PR DESCRIPTION
I'm not sure I like the result count because it's not actually very useful when you have >1 page. It's almost always going to be `50` unless you're on the last page of results.

@zrpnr, I think you might have thought that this would be a total of results across all pages? Then it'd make more sense because it would change w/ filters. That's not possible with stock JSON:API though.

===

In addition to surfacing the result count. I added some very basic handling for empty responses.